### PR TITLE
Make `resize2fs` work non-interactively.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -321,7 +321,7 @@ def partition_disk():
     run('umount /home')
     run('lvremove /dev/mapper/*home')
     run('lvresize -l +100%FREE /dev/mapper/*root')
-    run('if uname -r | grep -q el6; then resize2fs /dev/mapper/*root; '
+    run('if uname -r | grep -q el6; then resize2fs -f /dev/mapper/*root; '
         'else xfs_growfs /; fi')
 
 


### PR DESCRIPTION
BY passing `-f` to `resize2fs` we avoid having to confirm any changes,
as shown below:

``` bash
Do you really want to remove active logical volume home? [y/n]:
```
