### PR TITLE
Clean RHSM before unregistering.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -562,8 +562,8 @@ def client_registration_test(clean_beaker=True, update_packages=True):
     install_errata()
 
     # Clean up
-    clean_rhsm()
     unsubscribe()
+    clean_rhsm()
 
 
 def install_errata():


### PR DESCRIPTION
Flipped the order of tasks for cleaning up a system so that RHSM is
taken care of first, before unregistering.
