### PR TITLE
Do not prompt me when running `lvresize`.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -442,7 +442,7 @@ def partition_disk():
     """
     run('umount /home')
     run('lvremove /dev/mapper/*home')
-    run('lvresize -l +100%FREE /dev/mapper/*root')
+    run('lvresize -f -l +100%FREE /dev/mapper/*root')
     run('if uname -r | grep -q el6; then resize2fs -f /dev/mapper/*root; '
         'else xfs_growfs / && mount / -o inode64,remount; fi')
 


### PR DESCRIPTION
Noticed that `lvresize` prompts you before executing its command:

`Do you really want to remove active logical volume lv_home? [y/n]:`

This change adds `-f` to force the command to run non-interactively.
