### PR TITLE
Allows accepting modified (UUID) redhat-manifest by using a fake-manifest-ca.crt

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -516,6 +516,14 @@ def reservation_install(task_name, admin_password=None):
     if task_name == 'satellite':
         execute(install_satellite, admin_password, host=env['vm_ip'])
         execute(setup_default_capsule, host=env['vm_ip'])
+    
+    # Allows accepting modified (UUID) redhat-manifest by using a fake-manifest-ca.crt
+    run('wget -O /etc/candlepin/certs/upstream/fake_manifest.crt http://cosmos.lab.eng.pnq.redhat.com/rhel64/fake_manifest.crt')
+
+    if 'el6' in os.uname()[2]:
+    	run('service tomcat6 restart')
+    else:
+    	run('systemctl restart tomcat')
 
 
 def partition_disk():


### PR DESCRIPTION
Some background as to why this is required.
1. All the manifests created/downloaded via the access.redhat.com are first signed by a RedHat private-key. This is private to RedHat and not shared.
2. This private-key's corresponding certificate is /etc/candlepin/certs/upstream/candlepin-redhat-ca.crt
3. As Satellite6 does not allow uploading of similar manifests to different Organizations, we need to clone the manifests and change the UUID.
4. But after modifying the manifest as the signature is no longer valid, we would need our own key/cert pairs to sign the modified manifest (with changed UUID).
5. The custom Key/Certs created by me were placed at:
   - [`Fake Key`](http://cosmos.lab.eng.pnq.redhat.com/rhel64/fake_manifest.key)
   - [`Fake Cert`](http://cosmos.lab.eng.pnq.redhat.com/rhel64/fake_manifest.crt)
6. Above `Fake Key` would be used to sign a cloned manifest each time it's created.
7. Above `Fake Cert` would be required to do a `signature check` while uploading the manifest.

This certificate is similar to the above candlepin-redhat-ca.crt and needs to be fetched and placed at the same location.

So we need to update the jenkins "Satellite6 setup job" to perform the below steps.

1) Place the [`Fake Cert`](http://cosmos.lab.eng.pnq.redhat.com/rhel64/fake_manifest.crt) CA at `/etc/candlepin/certs/upstream` on satellite6 Server.
2) Restart tomcat6 service

NOTE:- The manifest CA crt can be checked with the below command:

```
openssl x509 -in fake_manifest.crt -noout -text
```
