### PR TITLE
Add RHEL7 support for upstream installation

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -383,7 +383,8 @@ def install_nightly(admin_password=None, org_name=None, loc_name=None):
 
     # Make sure that SELinux is enabled
     run('setenforce 1')
-    run('cd katello-deploy && ./setup.rb --skip-installer rhel6')
+    run('cd katello-deploy && ./setup.rb --skip-installer '
+        'rhel{os_version}'.format(os_version=os_version))
     run('katello-installer -v -d '
         '--foreman-admin-password="{0}" '
         '--foreman-initial-organization="{1}" '


### PR DESCRIPTION
As katello-deploy have support to installation on RHEL7 we should start handling it correctly.
