### PR TITLE
Updated Docs to reflect new environ variables.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ Subscription Management
 
 Subscribe::
 
-    DISTRO=rhel7 RHN_USERNAME=user@example.com RHN_PASSWORD=mysecret \
+    RHN_USERNAME=user@example.com RHN_PASSWORD=mysecret \
     RHN_POOLID=poolid fab -H root@example.com subscribe
 
 Unsubscribe::
@@ -55,32 +55,32 @@ Satellite Installation
 
 To install a compose build::
 
-	RHN_USERNAME=user@example.com RHN_PASSWORD=mysecret DISTRO=rhel7 \
-	RHN_POOLID=poolid BASE_URL=http://example.com/Satellite/x86_64/os/ \
-	fab -H root@example.com \
-	subscribe \
-	install_prerequisites \
-	install_satellite \
-	setup_default_capsule
+    RHN_USERNAME=user@example.com RHN_PASSWORD=mysecret \
+    RHN_POOLID=poolid BASE_URL=http://example.com/Satellite/x86_64/os/ \
+    fab -H root@example.com \
+    subscribe \
+    install_prerequisites \
+    install_satellite \
+    setup_default_capsule
 
 
 To install a nightly build::
 
-	RHN_USERNAME=user@example.com RHN_PASSWORD=mysecret DISTRO=rhel7 \
-	RHN_POOLID=poolid \
-	fab -H root@example.com \
-	subscribe \
-	install_prerequisites \
-	install_nightly
+    RHN_USERNAME=user@example.com RHN_PASSWORD=mysecret \
+    RHN_POOLID=poolid \
+    fab -H root@example.com \
+    subscribe \
+    install_prerequisites \
+    install_nightly
 
 
 To install from the CDN::
 
-	RHN_USERNAME=user@example.com RHN_PASSWORD=mysecret DISTRO=rhel7 \
-	RHN_POOLID=poolid \
-	fab -H root@example.com \
-	cdn_install \
-	setup_default_capsule
+    RHN_USERNAME=user@example.com RHN_PASSWORD=mysecret \
+    RHN_POOLID=poolid \
+    fab -H root@example.com \
+    cdn_install \
+    setup_default_capsule
 
 
 All installer tasks will set the admin password to `changeme`.


### PR DESCRIPTION
The environmental variable `DISTRO` is no longer valid. Instead,
please use `OS_NAME` and `OS_VERSION`. For most tasks, if you don't
provide a value for `OS_VERSION`, then tests which make use of this
variable will default to the value of `7`.
