### PR TITLE
Increase poll subscribe retries

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -70,7 +70,7 @@ def subscribe(autosubscribe=False):
         has_pool_msg = (
             'This unit has already had the subscription matching pool ID'
         )
-        for _ in range(3):
+        for _ in range(10):
             result = run(
                 'subscription-manager subscribe --pool={0}'.format(rhn_poolid),
                 warn_only=True


### PR DESCRIPTION
Automation matrix have increased and the poll subscribe is failing again
due to the concurrent subscription. Because this is better to increase
to a higher number to make sure all machines gets subscribed to the
poll.
