### PR TITLE
Pass ``--os`` during nightly install.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -518,7 +518,7 @@ def install_nightly(admin_password=None, org_name=None, loc_name=None):
     # Make sure that SELinux is enabled
     run('setenforce 1')
     run('cd katello-deploy && ./setup.rb --skip-installer '
-        'rhel{os_version}'.format(os_version=os_version))
+        '--os rhel{os_version}'.format(os_version=os_version))
     run('katello-installer -v -d '
         '--foreman-admin-password="{0}" '
         '--foreman-initial-organization="{1}" '


### PR DESCRIPTION
We need to pass `--os` to the nightly installer in order to avoid some
of the issues we have seen while installing it on RHEL 7. According to
the installer:

``` bash
Usage: ./setup.rb [options]
        --os [OS]                    Set OS manually
        --devel                      Setup a development environment
        --devel-user [USERNAME]      User to setup development environment for
        --installer-options [OPTIONS]
                                     Options to pass to katello-installer
        --skip-installer             Skip the final installer command and print instead
        --deployment-dir [DIRECTORY] Set a custom path for installing to (defaults to /home/USERNAME)
        --version [VERSION]          Set the version of Katello to install nightly|2.0
```
