### PR TITLE
Improve vm_destroy task

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -489,7 +489,7 @@ def vm_destroy(target_image=None, image_dir=None, delete_image=False):
 
     if delete_image is True:
         image_name = '{target_image}.img'.format(target_image=target_image)
-        run('rm {image_path}'.format(
+        run('virsh vol-delete --pool default {image_path}'.format(
             image_path=os.path.join(image_dir, image_name)), warn_only=True)
 
 


### PR DESCRIPTION
Now vm_destroy uses virsh to remove the volume image because it removes
the image file and refreshes the volumes pool.
