### PR TITLE
Wrapped line to bring it within 80 chars.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,8 +107,8 @@ pygments_style = 'sphinx'
 # found.
 nitpicky = True
 
-# A list of (type, target) tuples (by default empty) that should be ignored when
-# generating warnings in “nitpicky mode”.
+# A list of (type, target) tuples (by default empty) that should be ignored
+# when generating warnings in “nitpicky mode”.
 # nitpick_ignore = [('py:obj', 'bool')]
 
 


### PR DESCRIPTION
This change will bring back green builds in travis.
## Before

```
$ flake8 .
$ ./docs/conf.py:110:80: E501 line too long (80 > 79 characters)
```
## After

```
$ flake8 .
$
```

fixes #97 
