### PR TITLE
Added new function to create a compose repo file

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1158,6 +1158,24 @@ def performance_tuning(running_on_vm=True):
         run('tuned-adm profile throughput-performance')
 
 
+def add_repo(repo_name=None, repo_url=None):
+    """Adds a new repo to the system based on the repo_url"""
+    if repo_url is not None:
+        if repo_name is None:
+            repo_name = urlsplit(repo_url).netloc
+        repo_file = (
+            '[{0}]\n'
+            'name={0}\n'
+            'baseurl={1}\n'
+            'enabled=1\n'.format(repo_name, repo_url)
+        )
+        with cd('/etc/yum.repos.d/'):
+            run('echo "{0}" >> automation-tools.repo'.format(repo_file))
+    else:
+        print('add_repo requires a repo_url to make any changes.')
+        sys.exit(1)
+
+
 # Client registration
 # ==================================================
 def clean_rhsm():

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,5 +1,6 @@
 """Module which publish all automation-tools tasks"""
 from automation_tools import (
+    add_repo,
     cdn_install,
     clean_rhsm,
     client_registration_test,


### PR DESCRIPTION
Requires the repo_url be passed in the command.
## Example

```
fab -H ibm-x3550m3-12.lab.eng.brq.redhat.com -u root -p '******' add_repo:'test','http://porkchop.devel.redhat.com/released/RHEL-7/7.0/Server/x86_64/os/';
[ibm-x3550m3-12.lab.eng.brq.redhat.com] Executing task 'add_repo'
[ibm-x3550m3-12.lab.eng.brq.redhat.com] run: echo "[test]
name=test
baseurl=http://porkchop.devel.redhat.com/released/RHEL-7/7.0/Server/x86_64/os/
enabled=1
" >> automation-tools.repo
```

Adresses #72 
