### PR TITLE
Added the missing package for abrt

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -393,12 +393,15 @@ def setup_abrt():
     packages = [
         'abrt-cli',
         'rubygem-smart_proxy_abrt',
-        'rubygem-smart_proxy_pulp'
+        'rubygem-smart_proxy_pulp',
+        'ruby193-rubygem-foreman_abrt'
     ]
     for package in packages:
         run('yum install -y {0}'.format(package))
 
     run('systemctl restart foreman')
+    # workaround as sometimes foreman service does not restart with systemctl
+    run('touch /usr/share/foreman/tmp/restart.txt')
 
     # edit the config files
     host = env['host']


### PR DESCRIPTION
This step is missing :
https://github.com/theforeman/foreman_abrt/blob/katello-docs/README.md#installing-the-foreman-plugin

Added as per the instructions given in README
please review it thanks