### PR TITLE
Setup default docker on product_install task

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -970,6 +970,8 @@ def product_install(distribution, create_vm=False, certificate_url=None):
     if distribution in ('cdn', 'downstream', 'iso'):
         execute(setup_default_capsule, host=host)
 
+    execute(setup_default_docker, host=host)
+
     # execute returns a dict, the result is the first value
     info = execute(distro_info, host=host).values()[0]
     if info[1] == 7:


### PR DESCRIPTION
Docker should be available to be used as a compute resource. Because
this setting up the default docker is needed to allow testing docker
product features.