### PR TITLE
Simplify commands

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -251,18 +251,17 @@ def setup_default_docker():
 
     # SElinux workaround let us use ``http://localhost:2375`` for a
     # ``Docker`` Compute Resurce.
-    options = [
+    options = ' '.join([
         '--selinux-enabled',
         '-H tcp://0.0.0.0:2375',
         '-H unix:///var/run/docker.sock',
-    ]
-
+    ])
     if os_version >= 7:
-        run('echo "OPTIONS={0}" >> /etc/sysconfig/docker'
-            ''.format(' '.join(options)))
+        run('echo OPTIONS={0} >> /etc/sysconfig/docker'.format(options))
     else:
-        run('echo "other_args=\\"{0}\\"" >> /etc/sysconfig/docker'
-            ''.format(' '.join(options)))
+        run(
+            r'echo other_args=\"{0}\" >> /etc/sysconfig/docker'.format(options)
+        )
 
     # Restart ``docker`` service
     if os_version >= 7:


### PR DESCRIPTION
Drop unnecessary quotes. The following four commands:

    $ echo other_args=foo
    $ echo other_args="foo"
    $ echo other_args=\"foo\"
    $ echo "other_args=\"foo\""

result in this output:

    other_args=foo
    other_args=foo
    other_args="foo"
    other_args="foo"

The outermost quotes serve no function beyond making the command harder to read.

Use raw strings. The following two strings are equivalent:

    'before \\ after'
    r'before \ after'

Make some other changes that make the code cleaner.