### PR TITLE
Fix command which populates /etc/sysconfig/docker

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -251,17 +251,14 @@ def setup_default_docker():
 
     # SElinux workaround let us use ``http://localhost:2375`` for a
     # ``Docker`` Compute Resurce.
-    options = ' '.join([
-        '--selinux-enabled',
-        '-H tcp://0.0.0.0:2375',
-        '-H unix:///var/run/docker.sock',
-    ])
-    if os_version >= 7:
-        run('echo OPTIONS={0} >> /etc/sysconfig/docker'.format(options))
-    else:
-        run(
-            r'echo other_args=\"{0}\" >> /etc/sysconfig/docker'.format(options)
-        )
+    run('sed -i -e "s|^{0}=.*|{0}=\'{1}\'|" /etc/sysconfig/docker'.format(
+        'OPTIONS' if os_version >= 7 else 'other_args',
+        ' '.join([
+            '--selinux-enabled true',
+            '--host tcp://0.0.0.0:2375',
+            '--host unix:///var/run/docker.sock',
+        ])
+    ))
 
     # Restart ``docker`` service
     if os_version >= 7:


### PR DESCRIPTION
The `setup_default_docker` fabric task is currently broken. It populates
`/etc/sysconfig/docker` on RHEL 6 remote hosts with this line:

    other_args=

Fix this so that the configuration file is populated with a proper value:

    other_args='--selinux-enabled true --host tcp://0.0.0.0:2375 --host unix:///var/run/docker.sock'

The relevant command is tricky because Python, fabric and bash each have a hand
in transforming the string before it is executed.