### PR TITLE
Fix sed regex

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -434,7 +434,7 @@ def setup_abrt():
     # edit the config files
     run('sed -i -e "s|^URL = .*|URL = https://{0}:8443/abrt/|" '
         '/etc/libreport/plugins/ureport.conf'.format(host))
-    run('sed -i -e "|# SSLVerify = no|SSLVerify = yes|" '
+    run('sed -i -e "s|# SSLVerify = no|SSLVerify = yes|" '
         '/etc/libreport/plugins/ureport.conf')
     run('sed -i -e "s|# SSLClientAuth = .*|SSLClientAuth = puppet|" '
         '/etc/libreport/plugins/ureport.conf')


### PR DESCRIPTION
Add a leading "s" to a sed regular expression. The lack of an "s" is a syntax
error.