### PR TITLE
Fix execution of setenforce task

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -939,7 +939,7 @@ def product_install(distribution, create_vm=False, certificate_url=None,
     execute(subscribe, host=host)
 
     execute(install_prerequisites, host=host)
-    execute(setenforce(selinux_mode), host=host)
+    execute(setenforce, selinux_mode, host=host)
     execute(install_tasks[distribution], host=host)
 
     if distribution in ('cdn', 'downstream', 'iso'):


### PR DESCRIPTION
setenforce is now being run by the execute function but its parameter
was not handle properly. This fixes that problem and properly call
setenforce using execute function.