### PR TITLE
Fix distro_info execution on product_install task

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -946,7 +946,9 @@ def product_install(distribution, create_vm=False, certificate_url=None,
         execute(setup_default_capsule, host=host)
 
     execute(setup_default_docker, host=host)
-    if distro_info()[1] == 6:
+    # execute returns a dict, the result is the first value. OS version is the
+    # resulting index 1
+    if execute(distro_info, host=host).values()[0][1] == 6:
         with warn_only():
             execute(setup_abrt, host=host)
     else:


### PR DESCRIPTION
As product install can run the tasks on the specified server on in a
virtual machine created, because this tasks should be executed using the
execute function. Execute distro_info on the correct host.