### PR TITLE
Open port 5000 TCP on install_prerequisites

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -683,6 +683,9 @@ def install_prerequisites():
     # Port 22 must be open for connections via ssh
     run('iptables -I INPUT -m state --state NEW -p tcp --dport 22 -j ACCEPT')
 
+    # Port 5000 must be open for Docker registry communication.
+    run('iptables -I INPUT -m state --state NEW -p tcp --dport 5000 -j ACCEPT')
+
     # To make the changes persistent across reboots when using the command line
     # use this command:
     run('iptables-save > /etc/sysconfig/iptables')


### PR DESCRIPTION
Port 5000 TCP are used to publish the Satellite docker registry for
docker repositories. That port need to be opened otherwise clients will
not be able to pull images from it.