### PR TITLE
Improve setup_vm_provisioning task

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -575,6 +575,7 @@ def setup_vm_provisioning(interface=None):
         'git',
         'kvm',
         'libguestfs-tools',
+        'nss-mdns',
         'openssl',
         'perl',
         'perl-Sys-Guestfs',


### PR DESCRIPTION
Install nss-mdns in order to make pinging created virtual machines
possible.

This is all credit to @kbidarkar. Thank you very much for your help.