### PR TITLE
Task to configure system for email notification.

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -353,6 +353,23 @@ def setup_default_capsule(interface=None):
     )
 
 
+def setup_email_notification(smtp=None):
+    """Configures system to handle email notification.
+
+    NOTE: this task needs a 'katello-service restart', so choose wisely when to
+    call it, preferably before another task that restarts the stack, such as
+    the 'setup_default_capsule' task.
+
+    :param str smtp: A valid URL to a SMTP server.
+
+    """
+
+    # edit the config file
+    if smtp is not None:
+        run('sed -i -e "s|address.*|address: {0}|" '
+            '/etc/foreman/email.yaml'.format(smtp))
+
+
 def setup_fake_manifest_certificate(certificate_url=None):
     """Task to setup a fake manifest certificate
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -25,6 +25,7 @@ from automation_tools import (
     setup_ddns,
     setup_default_capsule,
     setup_default_docker,
+    setup_email_notification,
     setup_fake_manifest_certificate,
     setup_firewall,
     setup_proxy,


### PR DESCRIPTION
This task will configure your Satellite 6 system to send out email
notifications. The task itself needs to restart the entire stack in
order to take effect (via katello-service restart). I chose not to
restart the stack within the task itself, but to let the user call it
when appropriate, preferably before another task that may already
restart all services, such as the ``setup_default_capsule`` task.