### PR TITLE
Fix a typo on firewall ports to be open

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -436,9 +436,9 @@ def setup_firewall():
         22,
         # Port 5000 must be open for Docker registry communication.
         5000,
-        # Ports 5466 and 5467 for qpidd
-        5466,
-        5467,
+        # Ports 5646 and 5647 for qpidd
+        5646,
+        5647,
         # Port 8443 for Katello access the Islated Capsule
         8443,
     )


### PR DESCRIPTION
Was a typo in the docs where pointed to open ports for qpidd, update the
firewall ports to the real ports. Thanks @omaciel who persisted on this
issue until finding the typo.