### PR TITLE
Fix setup_proxy task

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -151,9 +151,9 @@ def setup_proxy(run_katello_installer=True):
         'katello-proxy-url': 'http://{0}'.format(proxy_info.hostname),
         'katello-proxy-port': proxy_info.port,
     }
-    if proxy_info.username is None:
+    if proxy_info.username is not None:
         installer_options['katello-proxy-username'] = proxy_info.username
-    if proxy_info.password is None:
+    if proxy_info.password is not None:
         installer_options['katello-proxy-password'] = proxy_info.password
     if run_katello_installer:
         katello_installer(**installer_options)


### PR DESCRIPTION
In the previous refactor was checking for proxy username and password
being None to add the installer options. That is not right as we want to
set the username and password if they are not None.

All credits should go to @sghai who got this issue.