### PR TITLE
use regexp when parsing sumfile for iso_filename

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1027,7 +1027,7 @@ def iso_download(iso_url=None):
                 quiet=True,
             )
             if result.succeeded:
-                iso_filename = result.split('*')[1].strip()
+                iso_filename = search('\w+\s+\*?([^\s]+)', result).group(1)
                 break
 
         if iso_filename is None:


### PR DESCRIPTION
In some sumfiles there is no asterisk used as a separator, instead multiple spaces are used.
So  let's use regular expressions when parsing sumfile for iso_filename.
