### PR TITLE
Fix command syntax for enabling/disabling repos

### DIFF
--- a/automation_tools/repository.py
+++ b/automation_tools/repository.py
@@ -20,12 +20,13 @@ def disable_repos(*args):
 
         disable_repos('repo1', 'repo2')
 
-    Will run the command ``subscription-manager repos --disable repo1 repo2``.
+    Will run the command ``subscription-manager repos --disable "repo1"
+    --disable "repo2"``.
 
 
     """
-    run('subscription-manager repos --disable {0}'
-        .format(' '.join(['"{0}"'.format(repo) for repo in args])))
+    run('subscription-manager repos {0}'
+        .format(' '.join(['--disable "{0}"'.format(repo) for repo in args])))
 
 
 def delete_custom_repos(**args):
@@ -54,11 +55,12 @@ def enable_repos(*args, **kwargs):
 
         enable_repos('repo1', 'repo2')
 
-    Will run the command ``subscription-manager repos --enable repo1 repo2``.
+    Will run the command ``subscription-manager repos --enable "repo1" --enable
+    "repo2"``.
 
     """
-    run('subscription-manager repos --enable {0}'
-        .format(' '.join(['"{0}"'.format(repo) for repo in args])))
+    run('subscription-manager repos {0}'
+        .format(' '.join(['--enable "{0}"'.format(repo) for repo in args])))
 
 
 def create_custom_repos(**kwargs):


### PR DESCRIPTION
Subscription manager need that the `--enable` or `--disable` flag repeat
for every repository. Update the command generation to generate a
command in the expected subscription-manager format.

With the fix I run the task without any issue:

```
$fab -H root@server.com enable_repos:rhel-7-server-rpms,rhel-server-rhscl-7-rpms
[root@server.com] Executing task 'enable_repos'
[root@server.com] run: subscription-manager repos --enable "rhel-7-server-rpms" --enable "rhel-server-rhscl-7-rpms"
[root@server.com] out: Repository 'rhel-7-server-rpms' is enabled for this system.
[root@server.com] out: Repository 'rhel-server-rhscl-7-rpms' is enabled for this system.
[root@server.com] out:


Done.
Disconnecting from root@server.com... done.

$ fab -H root@server.com disable_repos:rhel-7-server-rpms,rhel-server-rhscl-7-rpms
[root@server.com] Executing task 'disable_repos'
[root@server.com] run: subscription-manager repos --disable "rhel-7-server-rpms" --disable "rhel-server-rhscl-7-rpms"
[root@server.com] out: Repository 'rhel-7-server-rpms' is disabled for this system.
[root@server.com] out: Repository 'rhel-server-rhscl-7-rpms' is disabled for this system.
[root@server.com] out:


Done.
Disconnecting from root@server.com... done.
```