### PR TITLE
Email configuration needs to trust internal CA.

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -303,6 +303,8 @@ def setup_email_notification(smtp=None):
     if smtp is not None:
         run('sed -i -e "s|address.*|address: {0}|" '
             '/etc/foreman/email.yaml'.format(smtp))
+        run('echo "    enable_starttls_auto: false" '
+            '>> /etc/foreman/email.yaml')
 
 
 def setup_fake_manifest_certificate(certificate_url=None):


### PR DESCRIPTION
For most setups, one needs to make sure that your Satellite trusts the
internal Red Hat CA on the server itself. Please see
[BZ 1215820](https://bugzilla.redhat.com/show_bug.cgi?id=1215820) for
more information.