### PR TITLE
Specify the tftp-server-name as the sat6 hostname

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -278,6 +278,7 @@ def setup_default_capsule(interface=None, run_katello_installer=True):
         'capsule-dhcp': 'true',
         'capsule-dhcp-interface': interface,
         'capsule-tftp': 'true',
+        'capsule-tftp-servername': hostname,
         'capsule-puppet': 'true',
         'capsule-puppetca': 'true',
         'capsule-register-in-foreman': 'true',


### PR DESCRIPTION
*) currently the tftp-server-name is picked up as nil or the
   docker ip, as default if not specified.
*) so, it's safe to explicitly specify
   --tftp-server-name <hostname>