### PR TITLE
Add workaround for Java on RHEL 6.6

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -721,6 +721,13 @@ def downstream_install(admin_password=None, run_katello_installer=True):
         remote_path='/etc/yum.repos.d/satellite.repo')
     satellite_repo.close()
 
+    info = distro_info()
+    if info == ('rhel', 6, 6):
+        # For default java-1.8.0-openjdk will be installed on RHEL 6.6 but it
+        # makes the katello-installer fail. Install java-1.7.0-openjdk which is
+        # the recommended version for RHEL 6.6.
+        run('yum install -y java-1.7.0-openjdk')
+
     # Install required packages for the installation
     run('yum install -y katello')
 


### PR DESCRIPTION
This workaround is needed in order to install downstream on RHEL 6.6
without getting an error. If Java is not installed will be selected the
1.8.0 one which make the build fail, but the 1.7.0 will make it work
properly.