### PR TITLE
Open port 8000 for Capsule communication

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -350,6 +350,8 @@ def setup_firewall():
         # Ports 5646 and 5647 for qpidd
         5646,
         5647,
+        # Port 8000 for foreman-proxy service
+        8000,
         # Port 8443 for Katello access the Islated Capsule
         8443,
     )


### PR DESCRIPTION
Now Capsule communication requires that port 8000 is open in order to
work. Even for the default capsule.