### PR TITLE
Revert "Remove java workaround for RHEL 66"

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -906,6 +906,8 @@ def product_install(distribution, create_vm=False, certificate_url=None,
     )
     execute(update_packages, warn_only=True)
 
+    if distribution in ('satellite6-downstream', 'satellite6-iso'):
+        execute(java_workaround, host=host)
     # execute returns a dictionary mapping host strings to the given task's
     # return value
     installer_options.update(execute(
@@ -1381,6 +1383,16 @@ def foreman_debug(tarball_name=None, local_path=None):
 # =============================================================================
 # Helper functions
 # =============================================================================
+def java_workaround():
+    """By default java-1.8.0-openjdk will be installed on RHEL 6.6 but it makes
+    the katello-installer fail. Install java-1.7.0-openjdk which is the
+    recommended version for RHEL 6.6.
+
+    """
+    if distro_info() == ('rhel', 6, 6):
+        run('yum install -y java-1.7.0-openjdk')
+
+
 def katello_installer(debug=True, sam=False, verbose=True, **kwargs):
     """Runs the installer with ``kwargs`` as command options. If ``sam`` is
     True


### PR DESCRIPTION
Reverts SatelliteQE/automation-tools#191

katello-installer will install the latest java available which is version 1.8. But this will require to set the java 1.8 using the alternatives tool. Using java 1.7 will not require to do that because it have the highest priority and will be used by default because the alternatives will use the higher priority java.

```
# alternatives --display java | grep priority
/usr/lib/jvm/jre-1.5.0-gcj/bin/java - priority 1500
/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.45-28.b13.el6_6.x86_64/jre/bin/java - priority 37
/usr/lib/jvm/jre-1.7.0-openjdk.x86_64/bin/java - priority 170079
```

Reverting the java workaround because if we don't do that, we will need to install java using the latest version and then configure it using the alternatives tool. If is better to aways use the latest java then we will need to adjust the task to properly configure java and the following command will help:

```
alternatives --set java $(alternatives --display java | grep "^/usr/lib/jvm/java" | awk '{print $1}')
```