### PR TITLE
Fix dependency specification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 install:
     - pip install flake8
+    - pip install -r requirements.txt
 script:
     - flake8 .
 notifications:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
-Fabric
-novaclient
+# "Now your `pip install -r requirements.txt` will work just as before. It will
+# first install the library located at the file path `.` and then move on to
+# its abstract dependencies"
+#
+# See: https://caremad.io/2013/07/setup-vs-requirement/
+
+--editable .

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,6 @@ try:
 except ImportError:
     from distutils.core import setup
 
-packages = [
-    'automation_tools',
-]
-
-requires = [
-    'Fabric',
-]
-
 with open('README.rst', 'r') as f:
     readme = f.read()
 
@@ -25,11 +17,11 @@ setup(
     author=u'Elyézer Rezende',
     author_email='erezende@redhat.com',
     url='https://github.com/SatelliteQE/automation-tools',
-    packages=packages,
+    packages=['automation_tools'],
     package_data={'': ['LICENSE']},
     package_dir={'automation_tools': 'automation_tools'},
     include_package_data=True,
-    install_requires=requires,
+    install_requires=['Fabric', 'python-novaclient'],
     license='GNU GPL v3.0',
     classifiers=(
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
* Make `requirements.txt` reference `setup.py`. This means that there is a
  single authoritative list of dependencies.
* Make Travis install dependencies as part of the test process.
* Move all requirements to `setup.py`. This should let pip install
  automation-tools' dependencies when automation-tools is itself a dependency.

Here's a log from my own system, indicating that the fix works correctly:

    $ virtualenv --python python2 env
    $ source env/bin/activate
    $ git clone git@github.com:SatelliteQE/robottelo.git
    $ cd robottelo
    $ vim requirements.txt  # -e /home/ichimonji10/code/automation-tools
    $ pip install -r requirements.txt
    $ python  # import novaclient