### PR TITLE
Fixes the update packages bug

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -918,7 +918,9 @@ def product_install(distribution, create_vm=False, certificate_url=None,
         beta=distribution.endswith('beta'),
         host=host
     )
-    execute(update_packages, warn_only=True)
+
+    # Update the machine
+    update_packages(warn_only=True)
 
     if distribution in ('satellite6-downstream', 'satellite6-iso'):
         execute(java_workaround, host=host)


### PR DESCRIPTION
- The update_packages function tries to update the hypervisor rather than the intended vm due to fab context change

Note: I am not able to reproduce the bug locally and this happens only in the automation host-vm setup.