### PR TITLE
Add workaround for qdrouterd to listen to IPv6

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -964,6 +964,19 @@ def product_install(distribution, create_vm=False, certificate_url=None,
             host=host
         )
 
+    execute(fix_qdrouterd_listen_to_ipv6, host=host)
+
+
+def fix_qdrouterd_listen_to_ipv6():
+    """Configure qdrouterd to listen to IPv6 instead of IPv4.
+
+    Workaround for BZ #1219902.
+
+    """
+    run('sed -i -e "0,/addr: 0.0.0.0/s/addr: 0.0.0.0/addr: ::/" '
+        '/etc/qpid-dispatch/qdrouterd.conf')
+    manage_daemon('restart', 'qdrouterd')
+
 
 def partition_disk():
     """Re-partitions disk to increase the size of /root to handle

--- a/fabfile.py
+++ b/fabfile.py
@@ -10,6 +10,7 @@ from automation_tools import (  # flake8: noqa
     downstream_install,
     errata_upgrade,
     fix_hostname,
+    fix_qdrouterd_listen_to_ipv6,
     foreman_debug,
     get_hostname_from_ip,
     install_errata,


### PR DESCRIPTION
By default, `qdrouterd` is only listening to IPv4.
Content-hosts, created from VM-images in our automation are trying to connect through IPv6.
There's already a bug opened for `qdrouterd` to make it listen to IPv6 - [BZ1219902](https://bugzilla.redhat.com/show_bug.cgi?id=1219902).
As there're some content-host tests upcoming, i suggest applying this workaround, which basically editі the `qdrouterd` config and restarts the service at the end of sat installation.