### PR TITLE
Add katello_service task

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -18,6 +18,7 @@ from automation_tools import (  # flake8: noqa
     install_prerequisites,
     iso_download,
     iso_install,
+    katello_service,
     partition_disk,
     performance_tuning,
     product_install,


### PR DESCRIPTION
The task runs the katello-service on the server.

Also move the setup_default_docker after running katello-installer to
ensure that the installer succeed with only the expected repositories.
As SCAP is not available on SAM, just run its setup for satellite6
installations.

Closes #213