### PR TITLE
Fix for fabric to prevent losing of host context

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1532,7 +1532,7 @@ def katello_service(action, exclude=None):
         exclude = ''
     else:
         exclude = '--exclude {}'.format(','.join(exclude))
-    return run('katello-service {} {}'.format(exclude, action))
+    run('katello-service {} {}'.format(exclude, action))
 
 
 def manage_daemon(action, daemon, pty=True, warn_only=False):


### PR DESCRIPTION
Fabric loses the host context during katello-service call.  Since this can't be tested locally, I am not sure yet if this fix will really fix the problem.  I am going to attempt to merge this to get the automation going.