### PR TITLE
Install selected version of Sat server from CDN

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -833,7 +833,7 @@ def sam_upstream_install(admin_password=None):
 
 
 def product_install(distribution, create_vm=False, certificate_url=None,
-                    selinux_mode=None):
+                    selinux_mode=None, sat_cdn_version=None):
     """Task which install every product distribution.
 
     Product distributions are sam-upstream, satellite6-cdn,
@@ -877,6 +877,9 @@ def product_install(distribution, create_vm=False, certificate_url=None,
             distribution, ', '.join(distributions)))
         sys.exit(1)
 
+    if sat_cdn_version not in ('6.0', '6.1'):
+        raise ValueError("Satellite version should be either 6.0 or 6.1")
+
     if selinux_mode is None:
         selinux_mode = os.environ.get('SELINUX_MODE', 'enforcing')
 
@@ -911,6 +914,7 @@ def product_install(distribution, create_vm=False, certificate_url=None,
         enable_satellite_repos,
         cdn=distribution.endswith('cdn'),
         beta=distribution.endswith('beta'),
+        version=sat_cdn_version,
         host=host
     )
 

--- a/automation_tools/repository.py
+++ b/automation_tools/repository.py
@@ -125,7 +125,8 @@ def create_custom_repos(**kwargs):
         repo_file.close()
 
 
-def enable_satellite_repos(cdn=False, beta=False, disable_enabled=True):
+def enable_satellite_repos(cdn=False, beta=False, disable_enabled=True,
+                           cdn_version='6.1'):
     """Enable repositories required to install Satellite 6
 
     :param cdn: Indicates if the CDN Satellite 6 repo should be enabled or not
@@ -135,6 +136,8 @@ def enable_satellite_repos(cdn=False, beta=False, disable_enabled=True):
         stable one.
     :param disable_enabled: If True, disable all repositories (including beaker
         repositories) before enabling repositories.
+    :param version: Indicates which satellite version should be installed,
+        default set to 6.1.
 
     """
     if isinstance(cdn, str):
@@ -154,8 +157,13 @@ def enable_satellite_repos(cdn=False, beta=False, disable_enabled=True):
     ]
     if beta is True:
         repos.append('rhel-server-{0}-satellite-6-beta-rpms')
-    elif cdn is True:
-        repos.append('rhel-{0}-server-satellite-6.1-rpms')
+    if cdn is True:
+        if cdn_version == '6.0':
+            repos.append('rhel-{0}-server-satellite-6.0-rpms')
+        elif cdn_version == '6.1':
+            repos.append('rhel-{0}-server-satellite-6.1-rpms')
+        else:
+            raise ValueError('CDN Version should be either 6.0 or 6.1')
 
     enable_repos(*[repo.format(distro_info()[1]) for repo in repos])
     run('yum repolist')


### PR DESCRIPTION
I just updated the `product_install` function and `repository` to enable subscriptions based on given sat version for CDN distribution.

Will update the jenkins installer job later.