### PR TITLE
Removed discovery image install for upstream

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1001,8 +1001,8 @@ def product_install(distribution, create_vm=False, certificate_url=None,
     if distribution.startswith('satellite6'):
         execute(setup_default_docker, host=host)
         execute(katello_service, 'restart', host=host)
-        execute(setup_foreman_discovery, host=host)
         if not distribution.endswith('upstream'):
+            execute(setup_foreman_discovery, host=host)
             execute(install_puppet_scap_client, host=host)
             execute(setup_oscap, host=host)
 


### PR DESCRIPTION
Since we don't have package for discovery image in upstream. So this task is not applicable for upstream.

Thanks @kbidarkar for pointing this.