### PR TITLE
Product Upgrade with new Capsule Upgrade

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -1,9 +1,12 @@
 """Module which publish all automation-tools tasks"""
 from automation_tools import (  # flake8: noqa
     add_repo,
+    capsule6_upgrade,
+    capsule_certs_generate,
     cdn_install,
     clean_rhsm,
     client_registration_test,
+    copy_ssh_key,
     create_openstack_instance,
     create_personal_git_repo,
     delete_openstack_instance,
@@ -13,6 +16,7 @@ from automation_tools import (  # flake8: noqa
     fix_qdrouterd_listen_to_ipv6,
     foreman_debug,
     get_hostname_from_ip,
+    host_pings,
     install_errata,
     install_katello_agent,
     install_prerequisites,
@@ -36,6 +40,7 @@ from automation_tools import (  # flake8: noqa
     setup_proxy,
     setup_vm_provisioning,
     subscribe,
+    sync_capsule_tools_repos_to_upgrade,
     unsubscribe,
     update_basic_packages,
     update_rhsm_stage,


### PR DESCRIPTION
A new addition to the Product Upgrade automation feature that is Capsule Upgrade.

This includes,
1. Renewed product_upgrade function which now supports capsule upgrade.
2. New capsule6_upgrade function.
3. And the helper functions to achieve capsule upgrade.

The procedure/command to run Capsule upgrade is as follow:
1. The already created openstack image having capsule 6.0.8 should be available.
2. Capsule should be already connected to openstack satellite image having Satellite 6.0.8, so that both will be upgraded.
3. The ssh key of the running machine should already available in openstack project to add in capsule instance and to perform capsule upgrade operations.

Fab Command:
```
#RHN_USERNAME=<cdn_username> RHN_PASSWORD=<cdn_password> RHN_POOLID=<cdn_pool_id> USERNAME=<openstack_username> PASSWORD=<password> AUTH_URL=http://<openstack_server>:<port>/<version> PROJECT_ID=<project_id> BASE_URL=http://example.com/Satellite/x86_64/os/  CAPSULE_URL=http://example.com/Capsule/x86_64_os/ TOOLS_URL=http://example.com/Sat_Tools/x86_64_os/
fab -i <local private_ssh_key> product_upgrade:<product_name e.g 'capsule'>, <ssh_key>,<sat_instance_name>,<sat_image_name>,<sat_instance_flavor>,<cap_instance_name>,<cap_image_name>,<cap_instance_flavor>
```
Important:
The upgrade execution switches as per product_name. 
IF product == 'satellite':
       THEN 'Do only satellite upgrade'
ELSE IF product == 'capsule':
       THEN 'First do Satellite upgrade and then capsule upgrade'
ELSE:
       RETRY

Welcome suggestions and comments.