### PR TITLE
Fix import on fabfile

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -2,7 +2,6 @@
 from automation_tools import (  # flake8: noqa
     add_repo,
     satellite6_capsule_upgrade,
-    capsule_certs_generate,
     cdn_install,
     clean_rhsm,
     client_registration_test,


### PR DESCRIPTION
Remove capsule_certs_generate import as that task does not exist
anymore.