### PR TITLE
Force Create the Capsule cert in Capsule upgrade

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2155,6 +2155,7 @@ def satellite6_capsule_upgrade(admin_password=None):
     execute(
         generate_capsule_certs,
         cap_host,
+        True,
         host=sat_host
     )
     # Copying the capsule cert to capsule


### PR DESCRIPTION
Force Create the Capsule Cert while doing upgrade because already there is one used to setup the capsule. And hence for upgrading the capsule we need to create one more. So force creating capsule cert even if already present.