### PR TITLE
Deploy libvirt host ssh key for foreman account too

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -39,6 +39,7 @@ from automation_tools import (  # flake8: noqa
     setup_email_notification,
     setup_fake_manifest_certificate,
     setup_firewall,
+    setup_libvirt_key,
     setup_proxy,
     setup_vm_provisioning,
     subscribe,


### PR DESCRIPTION
We need to deploy ssh key not only for root account (/root/.ssh/id_rsa) utilized by automation
But also for foreman account (/usr/share/foreman/.ssh/id_rsa) utilized by Satellite itself when accessing libvirt compute resource using qemu+ssh://


(Fixes #277)