### PR TITLE
Runs katello-installer in debug mode.

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1725,6 +1725,8 @@ def katello_installer(debug=False, sam=False, verbose=True, **kwargs):
             extra_options.append(
                 '--capsule-dns-forwarders="{0}"'.format(forwarder))
 
+    debug = (debug or os.environ.get('DEBUG', '') == 'true')
+
     run('{0}-installer {1} {2} {3} {4}'.format(
         'sam' if sam else 'katello',
         '-d' if debug else '',


### PR DESCRIPTION
a) katello-installer runs in debug mode
b) This will also cause the parameters being passed to
   katello-installer to not get saved to answers-file.