### PR TITLE
Added enable_gateway_ports_connections()

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2582,3 +2582,9 @@ def relink_manifest(manifest_file=None):
     run('unlink /opt/manifests/manifest-latest.zip')
     run('ln -s {0} /opt/manifests/manifest-latest.zip'
         .format(new_manifest_file))
+
+
+def enable_gateway_ports_connections():
+    """Required by remote connections to SSH tunnels"""
+    run('sed "s/^[#]*GatewayPorts.*/GatewayPorts yes/" /etc/ssh/sshd_config')
+    manage_daemon('restart', 'sshd')

--- a/fabfile.py
+++ b/fabfile.py
@@ -11,6 +11,7 @@ from automation_tools import (  # flake8: noqa
     delete_openstack_instance,
     download_manifest,
     downstream_install,
+    enable_gateway_ports_connections,
     errata_upgrade,
     fix_hostname,
     fix_qdrouterd_listen_to_ipv6,


### PR DESCRIPTION
Allows the remote connections to SSH remote port forwards.
This will be used mainly for creating fake proxies.