### PR TITLE
Allow additional options to the installer when doing a product_install

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1122,6 +1122,13 @@ def product_install(distribution, create_vm=False, certificate_url=None,
                 setup_proxy, host=host, run_katello_installer=False
             )[host])
 
+    if os.environ.get('INSTALLER_OPTIONS'):
+        # INSTALLER_OPTIONS are comma separated katello-installer options.
+        # It will be of the form "key1=val1,key2=val2".
+        ins_opt = os.environ.get('INSTALLER_OPTIONS')
+        ins_opt_dict = dict(i.split('=') for i in ins_opt.split(','))
+        installer_options.update(ins_opt_dict)
+
     execute(
         katello_installer,
         host=host,


### PR DESCRIPTION
*) Helps in passing ad-hoc options to katello-installer at runtime,
   which is while installing a satellite6 using sat6-installer job.
*) Could also be helpful when we need to disable certain buggy
   capsule features and just proceed with the required stable
   sat6 setup.