### PR TITLE
Fix the foreman_key_file path

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -496,7 +496,7 @@ def setup_libvirt_key():
         URL of relevant SSH key used for authentication to libvirt machine
     """
     root_key_file = '/root/.ssh/id_rsa'
-    foreman_key_file = '~/foreman/.ssh/id_rsa'
+    foreman_key_file = '~/.ssh/id_rsa'
     key_url = os.environ.get('LIBVIRT_KEY_URL')
     libvirt_host = os.environ.get('LIBVIRT_HOSTNAME')
 


### PR DESCRIPTION
*) Fixed the foreman_key_file path, by excluding the username
   foreman from it.
*) As foreman user's home_dir is /usr/share/foreman/