### PR TITLE
set_yum_debug_level() function added

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2599,3 +2599,8 @@ def enable_gateway_ports_connections():
     """Required by remote connections to SSH tunnels"""
     run('sed -i "s/^[#]*GatewayPorts.*/GatewayPorts yes/" /etc/ssh/sshd_config')
     manage_daemon('restart', 'sshd')
+
+
+def set_yum_debug_level(level=1):
+    """Set default debug level for yum output"""
+    run('sed -i "s/^[#]*debuglevel=.*/debuglevel={}/" /etc/yum.conf'.format(level))

--- a/fabfile.py
+++ b/fabfile.py
@@ -33,6 +33,7 @@ from automation_tools import (  # flake8: noqa
     relink_manifest,
     run_errata,
     satellite6_upgrade,
+    set_yum_debug_level,
     setup_abrt,
     setup_ddns,
     setup_default_capsule,


### PR DESCRIPTION
implements https://github.com/SatelliteQE/automation-tools/issues/296
the  function that sets `debuglevel` value in `/etc/yum/yum.conf`.
Defaults to `1` which hides some progress bar graphics and makes yum output less talky.