### PR TITLE
Added support for running installer for Satellite6.2

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -274,30 +274,36 @@ def setup_default_capsule(interface=None, run_katello_installer=True):
             print('Was not possible to fetch interface information')
             sys.exit(1)
 
+    proxy = 'capsule'
+    if os.environ.get('SATELLITE_VERSION') == '6.2':
+        proxy = 'foreman-proxy'
+
     installer_options = {
-        'capsule-dns': 'true',
-        'capsule-dns-forwarders': forwarders,
-        'capsule-dns-interface': interface,
-        'capsule-dns-zone': domain,
-        'capsule-dhcp': 'true',
-        'capsule-dhcp-interface': interface,
-        'capsule-tftp': 'true',
-        'capsule-tftp-servername': hostname,
+        '{0}-dns'.format(proxy): 'true',
+        '{0}-dns-forwarders'.format(proxy): forwarders,
+        '{0}-dns-interface'.format(proxy): interface,
+        '{0}-dns-zone.format(proxy)': domain,
+        '{0}-dhcp'.format(proxy): 'true',
+        '{0}-dhcp-interface'.format(proxy): interface,
+        '{0}-tftp'.format(proxy): 'true',
+        '{0}-tftp-servername'.format(proxy): hostname,
         'capsule-puppet': 'true',
-        'capsule-puppetca': 'true',
-        'capsule-register-in-foreman': 'true',
+        '{0}-puppetca'.format(proxy): 'true',
+        '{0}-register-in-foreman'.format(proxy): 'true',
     }
 
     if 'DHCP_RANGE' in os.environ:
-        installer_options['capsule-dhcp-range'] = os.environ.get('DHCP_RANGE')
+        installer_options[
+            '{0}-dhcp-range'.format(proxy)
+        ] = os.environ.get('DHCP_RANGE')
 
     if 'GATEWAY' in os.environ:
         gateway = os.environ.get('GATEWAY')
-        installer_options['capsule-dhcp-gateway'] = gateway
+        installer_options['{0}-dhcp-gateway'.format(proxy)] = gateway
         zone = gateway.rpartition('.')[0]
         reversed_zone = '.'.join(reversed(zone.split('.')))
         dns_reverse_zone = '{0}.in-addr.arpa'.format(reversed_zone)
-        installer_options['capsule-dns-reverse'] = dns_reverse_zone
+        installer_options['{0}-dns-reverse'.format(proxy)] = dns_reverse_zone
 
     if run_katello_installer:
         katello_installer(**installer_options)
@@ -864,7 +870,10 @@ def downstream_install(admin_password=None, run_katello_installer=True):
     satellite_repo.close()
 
     # Install required packages for the installation
-    run('yum install -y katello')
+    if os.environ.get('SATELLITE_VERSION') == '6.2':
+        run('yum install -y satellite')
+    else:
+        run('yum install -y katello')
 
     installer_options = {
         'foreman-admin-password': admin_password,
@@ -1057,6 +1066,9 @@ def product_install(distribution, create_vm=False, certificate_url=None,
                     host=env['vm_ip']
                 )
 
+    # Fetch the Satellite Version information.
+    satellite_version = os.environ.get('SATELLITE_VERSION')
+
     # When creating a vm the vm_ip will be set, otherwise use the fabric host
     host = env.get('vm_ip', env['host'])
 
@@ -1133,6 +1145,7 @@ def product_install(distribution, create_vm=False, certificate_url=None,
         katello_installer,
         host=host,
         sam=distribution.startswith('sam'),
+        sat_version=satellite_version,
         **installer_options
     )
 
@@ -1717,24 +1730,33 @@ def java_workaround():
         run('yum install -y java-1.7.0-openjdk')
 
 
-def katello_installer(debug=False, sam=False, verbose=True, **kwargs):
+def katello_installer(debug=False, sam=False, verbose=True, sat_version='6.2',
+                      **kwargs):
     """Runs the installer with ``kwargs`` as command options. If ``sam`` is
     True
 
     """
-    # capsule-dns-forwarders should be repeated if setting more than one value
-    # check if a list is being received and repeat the option with different
-    # values
+    # capsule-dns-forwarders should be repeated if setting more than one
+    # value check if a list is being received and repeat the option with
+    # different values
+    proxy = 'capsule'
+    installer = 'katello'
+    if sam:
+        sat_version = ''
+    if sat_version == '6.2':
+        proxy = 'foreman-proxy'
+        installer = 'foreman'
     extra_options = []
-    if ('capsule-dns-forwarders' in kwargs and
-            isinstance(kwargs['capsule-dns-forwarders'], list)):
-        forwarders = kwargs.pop('capsule-dns-forwarders')
+    if ('{0}-dns-forwarders'.format(proxy) in kwargs and
+            isinstance(kwargs['{0}-dns-forwarders'.format(proxy)], list)):
+        forwarders = kwargs.pop('{0}-dns-forwarders'.format(proxy))
         for forwarder in forwarders:
             extra_options.append(
-                '--capsule-dns-forwarders="{0}"'.format(forwarder))
+                '--{0}-dns-forwarders="{1}"'.format(proxy, forwarder))
 
-    run('{0}-installer {1} {2} {3} {4}'.format(
-        'sam' if sam else 'katello',
+    run('{0}-installer {1} {2} {3} {4} {5}'.format(
+        'sam' if sam else installer,
+        '--scenario katello' if installer == 'foreman' else '',
         '-d' if debug else '',
         '-v' if verbose else '',
         ' '.join([
@@ -2600,4 +2622,7 @@ def enable_gateway_ports_connections():
 
 def set_yum_debug_level(level=1):
     """Set default debug level for yum output"""
-    run('sed -i "s/^[#]*debuglevel=.*/debuglevel={}/" /etc/yum.conf'.format(level))
+    run(
+        'sed -i "s/^[#]*debuglevel=.*/debuglevel={}/" /etc/yum.conf'
+        .format(level)
+    )


### PR DESCRIPTION
a) The changes are compatible for Sat6.0 and Sat6.1
   installations.
b) SATELLITE_VERSION env variable is mandatory and needs to be
   set for Satellite6.2 installation and will no longer be used
   just for provisioning.
c) katello-installer or foreman-installer will be invoked
   depending upon the SATELLITE_VERSION ENV variable.
d) Capsule Features will get configured as 'capsule-dns' or
   'foreman-proxy-dns' depending upon the SATELLITE_VERSION
   ENV variable.