### PR TITLE
fixes - #305 - setup_firewall() got broken

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -392,8 +392,8 @@ def setup_firewall():
         'udp': udp_ports,
     }
 
-    for protocol, ports in definitions:
-        for port in ports:
+    for protocol in definitions:
+        for port in definitions[protocol]:
             rule_exists = run(
                 r'iptables -nL INPUT | grep -E "^ACCEPT\s+{0}.*{1}"'.format(protocol, port),
                 quiet=True,


### PR DESCRIPTION
fixes #305 

```bash
$ fab -i ~/.ssh/rb.priv -H root@my.server.com setup_firewall
[root@my.server.com] Executing task 'setup_firewall'
[root@my.server.com] run: iptables -I INPUT -m state --state NEW -p tcp --dport 5000 -j ACCEPT
[root@my.server.com] run: iptables -I INPUT -m state --state NEW -p tcp --dport 5646 -j ACCEPT
[root@my.server.com] run: iptables -I INPUT -m state --state NEW -p tcp --dport 5647 -j ACCEPT
[root@my.server.com] run: iptables -I INPUT -m state --state NEW -p tcp --dport 8000 -j ACCEPT
[root@my.server.com] run: iptables -I INPUT -m state --state NEW -p tcp --dport 8443 -j ACCEPT
[root@my.server.com] run: iptables-save > /etc/sysconfig/iptables

Done.
Disconnecting from root@my.server.com... done.
```