### PR TITLE
Capsule provisioning

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -41,6 +41,8 @@ from automation_tools import (  # flake8: noqa
     setup_email_notification,
     setup_fake_manifest_certificate,
     setup_firewall,
+    setup_capsule_firewall,
+    setup_satellite_firewall,
     setup_libvirt_key,
     setup_proxy,
     setup_vm_provisioning,


### PR DESCRIPTION
Add setup_capsule_firewall task and update the setup_firewall to
setup_satellite_firewall. The setup_firewall task now is a helper for
setting up firewall rules and using iptables on RHEL6 and firewall-cmd
on RHEL7.

Add setup_capsule_content task to help setting up a custom content on
the Satellite Server that allow creating a capsule.

Update capsule_installer to match the new way to run the capsule
installer.

Update setup_capsules to not start content sync. This may be added later
if syncing is something really needed.