### PR TITLE
Fix #310 calling disable_repos for 'extras' after Docker installation

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -194,6 +194,8 @@ def setup_default_docker():
     # Install ``Docker`` package.
     if os_version >= 7:
         run('yum install -y docker', warn_only=True)
+        # Disable 'extras' repo after installing Docker
+        disable_repos('rhel-{0}-server-extras-rpms'.format(os_version))
     else:
         run('yum install -y docker-io', warn_only=True)
         # Delete EPEL repo files


### PR DESCRIPTION
Implemented using **disable_repos** function

tested with @elyezer 's help

output

```
[root@...] run: subscription-manager repos --disable "rhel-7-server-extras-rpms"
[root@...] out: Repository 'rhel-7-server-extras-rpms' is disabled for this system. 
```