### PR TITLE
Added set_yum_debug_level call to satellite6_upgrade and product_install

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1166,6 +1166,9 @@ def product_install(distribution, create_vm=False, certificate_url=None,
         execute(update_rhsm_stage, host=host)
     execute(subscribe, host=host)
 
+    # Setting yum stdout log level to be less verbose
+    execute(set_yum_debug_level)
+
     execute(install_prerequisites, host=host)
     execute(setenforce, selinux_mode, host=host)
     execute(
@@ -2297,6 +2300,8 @@ def satellite6_upgrade(admin_password=None):
     # Sync capsule and tools repo
     if admin_password is None:
         admin_password = os.environ.get('ADMIN_PASSWORD', 'changeme')
+    # Setting yum stdout log level to be less verbose
+    execute(set_yum_debug_level)
     # Removing rhel-released and rhel-optional repo
     run('rm -rf /etc/yum.repos.d/rhel-{optional,released}.repo')
     print('Wait till Packages update ... ')


### PR DESCRIPTION
This should save us from a long useless yum stdout. It will set yum loglevel to 1 which only prints out a list summary of packages that have been manipulated (no progressbars, etc.). Yum also runs faster