### PR TITLE
Fix distro_info call on product_install task

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1275,8 +1275,7 @@ def product_install(distribution, create_vm=False, certificate_url=None,
             if os.environ.get('SATELLITE_VERSION') != '6.0':
                 execute(install_puppet_scap_client, host=host)
                 # Workaround for bug 1329394 - Install oscap only on rhel 7
-                major_ver = distro_info()[1]
-                if major_ver == 7:
+                if execute(distro_info, host=host)[host][1] == 7:
                     execute(setup_oscap, host=host)
 
     certificate_url = certificate_url or os.environ.get(


### PR DESCRIPTION
Make sure that distro_info is run on the machine where Satellite is being
installed.

If you are interested on how things works under the hood check this out:

```
In [2]: execute(distro_info, host='localhost')
[localhost] Executing task 'distro_info'
fedora 22 None
Out[2]: {'localhost': ('fedora', 22, None)}

In [3]: execute(distro_info, host='localhost')['localhost']
[localhost] Executing task 'distro_info'
fedora 22 None
Out[3]: ('fedora', 22, None)

In [4]: execute(distro_info, host='localhost')['localhost'][1]
[localhost] Executing task 'distro_info'
fedora 22 None
Out[4]: 22
```