### PR TITLE
Get the docker clean up script ready to trigger it at the end of automation runs

### DIFF
--- a/misc/cleanup_scripts/clean_docker.sh
+++ b/misc/cleanup_scripts/clean_docker.sh
@@ -5,7 +5,7 @@ timestamp() {
 }
 echo "$(timestamp): Cleaning UP of Docker containers BEGINS" >> /var/log/cleanup_docker.log 2>&1
 echo "$(timestamp): Stopping all the running docker containers" >> /var/log/cleanup_docker.log 2>&1
-docker stop $(docker ps -a -q) >> /var/log/cleanup_docker.log 2>&1
+docker ps -a | grep 'days ago' | awk '{print $1}' | xargs --no-run-if-empty docker stop  >> /var/log/cleanup_docker.log 2>&1
 echo "$(timestamp): Removing all the docker containers" >> /var/log/cleanup_docker.log 2>&1
-docker rm $(docker ps -a -q) >> /var/log/cleanup_docker.log 2>&1
+docker ps -a | grep 'days ago' | awk '{print $1}' | xargs --no-run-if-empty docker rm  >> /var/log/cleanup_docker.log 2>&1
 echo "$(timestamp): Cleaning UP of Docker containers ENDS" >> /var/log/cleanup_docker.log 2>&1


### PR DESCRIPTION
Currently:
- the script runs every sunday at 6pm ET and it cleans up all the
containers.  This might potentially affect some running jobs too since the
automation takes a long time to run recently
- If there are any issues in containers in between the week, number of
containers start piling up.

Purpose of this fix:
- this script queries for the containers that are older than 2 days and
stop/remove them.  By this way, the recently created/needed containers wont be
deleted.
- Also after this PR, a new jenkins job will be created and it will be triggered
at the end of every automation run.