### PR TITLE
Store docker cleanup log to current folder

### DIFF
--- a/misc/cleanup_scripts/clean_docker.sh
+++ b/misc/cleanup_scripts/clean_docker.sh
@@ -3,9 +3,9 @@
 timestamp() {
   date +"%Y-%m-%d:%T"
 }
-echo "$(timestamp): Cleaning UP of Docker containers BEGINS" >> /var/log/cleanup_docker.log 2>&1
-echo "$(timestamp): Stopping all the running docker containers" >> /var/log/cleanup_docker.log 2>&1
-docker ps -a | grep 'days ago' | awk '{print $1}' | xargs --no-run-if-empty docker stop  >> /var/log/cleanup_docker.log 2>&1
-echo "$(timestamp): Removing all the docker containers" >> /var/log/cleanup_docker.log 2>&1
-docker ps -a | grep 'days ago' | awk '{print $1}' | xargs --no-run-if-empty docker rm  >> /var/log/cleanup_docker.log 2>&1
-echo "$(timestamp): Cleaning UP of Docker containers ENDS" >> /var/log/cleanup_docker.log 2>&1
+echo "$(timestamp): Cleaning UP of Docker containers BEGINS" >> cleanup_docker.log 2>&1
+echo "$(timestamp): Stopping all the running docker containers" >> cleanup_docker.log 2>&1
+docker ps -a | grep 'days ago' | awk '{print $1}' | xargs --no-run-if-empty docker stop  >> cleanup_docker.log 2>&1
+echo "$(timestamp): Removing all the docker containers" >> cleanup_docker.log 2>&1
+docker ps -a | grep 'days ago' | awk '{print $1}' | xargs --no-run-if-empty docker rm  >> cleanup_docker.log 2>&1
+echo "$(timestamp): Cleaning UP of Docker containers ENDS" >> cleanup_docker.log 2>&1


### PR DESCRIPTION
Since the cleanup is triggered from jenkins now, it is better to store the logs in the jenkins workspace instead of giving jenkins user access to system logs.