### PR TITLE
Capsule Upgrade Fix by optional ak,cv and env names

### DIFF
--- a/automation_tools/satellite6/upgrade/__init__.py
+++ b/automation_tools/satellite6/upgrade/__init__.py
@@ -254,7 +254,6 @@ def product_upgrade(
     CAPSULE_SUBSCRIPTION
         List of cv_name, environment, ak_name attached to subscription of
         capsule in defined sequence.
-        Optional, for upgrade on specific satellite and capsule.
     RHEV_SATELLITE
         The Satellite hostname on RHEVM instance.
         Optional, If want to run upgrade on RHEVM instance.


### PR DESCRIPTION
Now, CAPSULE_SUBSCRIPTION details are optional if not provided will be fetched from Jenkins environment.
Also CAPSULE_SUBSCRIPTION details has to be passed while running that function individually through fab, But for jenkins its optional.