### PR TITLE
Set capsule Hostname env variable in both the cases

### DIFF
--- a/automation_tools/satellite6/upgrade/__init__.py
+++ b/automation_tools/satellite6/upgrade/__init__.py
@@ -322,7 +322,7 @@ def product_upgrade(
             )
         else:
             cap_host = os.environ.get('CAPSULE_HOSTNAME')
-            env['capsule_host'] = cap_host
+        env['capsule_host'] = cap_host
         # Copy ssh key from satellie to capsule
         copy_ssh_key(sat_host, cap_host)
         if os.environ.get('CAPSULE_URL') is not None:


### PR DESCRIPTION
Set capsule Hostname fab env variable in both the cases:
1. When Given by Job User
2. Fetched from Jenkins Env Variables