### PR TITLE
enable docker service in rhel7 after installing it

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -189,6 +189,8 @@ def setup_default_docker():
     # Install ``Docker`` package.
     if os_version >= 7:
         run('yum install -y docker', warn_only=True)
+        # enable the service as it is disabled by default
+        run('systemctl enable docker.service')
         # Disable 'extras' repo after installing Docker
         disable_repos('rhel-{0}-server-extras-rpms'.format(os_version))
     else:


### PR DESCRIPTION
On RHEL7+ the `docker.service` is not being automatically enabled. Thus we need to enable it manually. Otherwise we'll end up with stopped `docker.service` everytime we spin up the system from a snapshot.