### PR TITLE
Setup Firewall rules before Capsule Upgrade command

### DIFF
--- a/automation_tools/satellite6/upgrade/__init__.py
+++ b/automation_tools/satellite6/upgrade/__init__.py
@@ -221,6 +221,8 @@ def satellite6_capsule_upgrade(admin_password=None):
         # Stopping the services again which started in reboot
         run('for i in qpidd pulp_workers pulp_celerybeat '
             'pulp_resource_manager httpd; do service $i stop; done')
+    # Setting Up firewall rules
+    setup_capsule_firewall()
     # Upgrading Katello installer
     print('CAPSULE UPGRADE started at: {0}'.format(time.ctime()))
     if to_version == '6.1':


### PR DESCRIPTION
The capsule upgrade is failing due to firewall issue during capsule upgrade installer command with error:
Failed to call refresh: Proxy CAPSULE_FQDN cannot be registered (422 Unprocessable Entity): Unable to communicate with the Capsule: ERF12-2530 [ProxyAPI::ProxyException]: Unable to detect features ([Errno::EHOSTUNREACH]: No route to host - connect(2) for CAPSULE_FQDN port...) for Capsule https://CAPSULE_FQDN:9090/features Please check the Capsule is configured and running on the host.

The issue is happening due to unable to connect to port 9090 on capsule. So setting firewall rules should fix this issue.