### PR TITLE
Revert "Disabling os update to investigate test slowness"

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1236,9 +1236,8 @@ def product_install(distribution, create_vm=False, certificate_url=None,
     if os.environ.get('OS_UPGRADE_REPO'):
         os_upgrade_repo = os.environ.get('OS_UPGRADE_REPO')
         execute(create_custom_repos, rhel_candidate=os_upgrade_repo, host=host)
-    # Disabling machine update temporarily
     # Update the machine
-    # execute(update_packages, host=host, warn_only=True)
+    execute(update_packages, host=host, warn_only=True)
 
     if distribution in ('satellite6-downstream', 'satellite6-iso'):
         execute(java_workaround, host=host)


### PR DESCRIPTION
CDN is slow. Unless we have updated OS image on daily basis, we are required to run OS update always before installing Satellite.

We say: "Prior installing Satellite run yum update", so lets again do it in automation.

