### PR TITLE
Enable ostree plugin also for upstream

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -604,17 +604,23 @@ def setup_foreman_discovery():
     run('rm -rf {0}'.format(template_file))
 
 
-def enable_ostree():
-    """Task to enable ostree plugin for Satellite on rhel7. This enables ostree
-    type repository.
+def enable_ostree(upstream=False):
+    """Task to enable ostree plugin for Satellite on rhel7.
+    This enables ostree type repository.
 
+    :param bool upstream: Flag whether we run on upstream. Default: ``False``.
     """
     os_version = distro_info()[1]
-    sat_version = os.environ.get('SATELLITE_VERSION')
-    # Enable ostree plugin only for Satellite6.2 installed on rhel7
-    if sat_version == '6.2' and os_version >= 7:
-        run('satellite-installer --scenario satellite '
-            '--katello-enable-ostree=true')
+    if os_version >= 7:
+        if upstream:
+            create_custom_repos(centos_atomic='http://buildlogs.centos.org/'
+                                'centos/7/atomic/x86_64/Packages/')
+        run('{}-installer --scenario {} --katello-enable-ostree=true'
+            .format(*['foreman', 'katello'] if upstream else ['satellite']*2))
+        if upstream:
+            delete_custom_repos('centos_atomic')
+    else:
+        print('ostree plugin is supported only on rhel7+')
 
 
 def setup_libvirt_key():
@@ -1340,12 +1346,15 @@ def product_install(distribution, create_vm=False, certificate_url=None,
                 execute(install_puppet_scap_client, host=host)
             if satellite_version == '6.1':
                 execute(setup_oscap, host=host)
-            if satellite_version in ('6.2', ''):
+            if satellite_version not in ('6.0', '6.1'):
                 execute(oscap_content, host=host)
-            execute(enable_ostree, host=host)
             # if we have PXE default template we can setup foreman discovery
             if os.environ.get('PXE_DEFAULT_TEMPLATE_URL') is not None:
                 execute(setup_foreman_discovery, host=host)
+        # ostree plugin is for Sat6.2+ and nightly (rhel7 only)
+        if satellite_version not in ('6.0', '6.1'):
+            execute(
+                enable_ostree, distribution.endswith('upstream'), host=host)
 
 
 def fix_qdrouterd_listen_to_ipv6():

--- a/fabfile.py
+++ b/fabfile.py
@@ -7,6 +7,7 @@ from automation_tools import (  # flake8: noqa
     create_personal_git_repo,
     download_manifest,
     downstream_install,
+    enable_ostree,
     errata_upgrade,
     fix_hostname,
     fix_qdrouterd_listen_to_ipv6,


### PR DESCRIPTION
Enable ostree plugin also for upstream
- enable_ostree() refactored to handle plugin enablement also in upstream

(Fixes #391)