### PR TITLE
Attemp to mitigate "Error: INVALID_ZONE"

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -390,6 +390,12 @@ def setup_firewall(definitions=None, flush=True):
         if run('systemctl status firewalld', quiet=True).failed:
             run('systemctl enable firewalld')
             run('systemctl start firewalld')
+        # FIXME attempt to mitigate "Error: INVALID_ZONE"
+        for i in range(5):
+            if run('firewall-cmd --list-all-zones', warn_only=True).succeeded:
+                break
+            time.sleep((i+1) * 5)
+
         exists_command = 'firewall-cmd --permanent --query-port="{1}/{0}"'
         command = 'firewall-cmd --permanent --add-port="{1}/{0}"'
         if flush:


### PR DESCRIPTION
Right after starting firewalld service we are submitting firewall-cmd commands.
Sometimes they fail sometimes not.
```
[hostname] run: systemctl start firewalld
[hostname] run: for port in $(firewall-cmd --permanent --list-ports); do firewall-cmd --permanent --remove-port="$port"; done
[hostname] out: Error: INVALID_ZONE
[hostname] out: Error: INVALID_ZONE
[hostname] out: 

Fatal error: run() received nonzero return code 112 while executing!
```
I added in between some checks for zones and some sleep. Sleep fixes things. Magic :-)