### PR TITLE
Fixes issues with flake8 and install satellite via repo_url and ak.

### DIFF
--- a/automation_tools/satellite6/hammer.py
+++ b/automation_tools/satellite6/hammer.py
@@ -234,8 +234,8 @@ def hammer_content_view_promote_version(
     :param organization_id: organization where the content view was created
     """
     return hammer('content-view version promote --content-view {0} --id {1} '
-                  '--lifecycle-environment-id {2} --organization-id 1'.format(
-                    cv_name, cv_ver_id, lc_env_id))
+                  '--lifecycle-environment-id {2} --organization-id 1'
+                  .format(cv_name, cv_ver_id, lc_env_id))
 
 
 @task


### PR DESCRIPTION
1) Fixes flake8 issues of PR 408

2) Updated the logic of PR 408, to subscribe for all distribution
methods and then unsubscribe for just 'satellite6-activationkey'.

3) Also now updating `distribution` instead of
`install_tasks[distribution]`