### PR TITLE
Added server-optional-rpms repo for installing grub2-efi-modules.

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1099,6 +1099,7 @@ def repofile_install(admin_password=None, run_katello_installer=True,
         URL for the compose repository file to fetch.
 
     """
+    os_version = distro_info()[1]
     if admin_password is None:
         admin_password = os.environ.get('ADMIN_PASSWORD', 'changeme')
 
@@ -1107,6 +1108,11 @@ def repofile_install(admin_password=None, run_katello_installer=True,
 
     run('yum install -y wget')
     run('wget -O /etc/yum.repos.d/satellite63.repo {0}'.format(repo_url))
+
+    # Enable required repository
+    if os_version == '7':
+        run('subscription-manager repos --enable "rhel-{0}-server-optional-rpms"'
+            .format(os_version))
 
     # Install required packages for the installation
     run('yum install -y satellite')


### PR DESCRIPTION
a) Will be adding this only for repofile_install

b) Installation with ak should not require enabling this and should
   be set to default via the dogfoods ak.