### PR TITLE
Fix no scenario for upstream installations and few fixes

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1374,6 +1374,8 @@ def product_install(distribution, create_vm=False, certificate_url=None,
     if satellite_version in ('6.1', '6.2'):
         if distribution in ('satellite6-repofile', 'satellite6-activationkey'):
             distribution = 'satellite6-downstream'
+    elif satellite_version == '6.3' and distribution == 'satellite6-downstream':
+        distribution = 'satellite6-activationkey'
 
     distributions = install_tasks.keys()
     installer_options = {}
@@ -2148,7 +2150,7 @@ def katello_installer(debug=False, distribution=None, verbose=True,
     run('{0}-installer {1} {2} {3} {4} {5}'.format(
         installer,
         '--scenario {0}'
-        .format(scenario) if sat_version in ('6.2', '6.3') else '',
+        .format(scenario) if sat_version in ('6.2', '6.3', 'nightly') else '',
         '-d' if debug else '',
         '-v' if verbose else '',
         ' '.join([


### PR DESCRIPTION
a) Earlier for upstream installation satellite_version was '6.2',
   But after the re-org, for upstream the satellite_version that
   needs to be selected is nightly for scenario to get populated.
b) Make sure `satellite6-activationkey` distribution is selected if
   if `satellite_version` is 6.3 and `distribution` is 'downstream'