### PR TITLE
[Do Not Merge] Fix repo_install as RHEL6 has also optional channel available

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1110,9 +1110,8 @@ def repofile_install(admin_password=None, run_katello_installer=True,
     run('wget -O /etc/yum.repos.d/satellite63.repo {0}'.format(repo_url))
 
     # Enable required repository
-    if os_version >= 7:
-        run('subscription-manager repos --enable "rhel-{0}-server-optional-rpms"'
-            .format(os_version))
+    run('subscription-manager repos --enable "rhel-{0}-server-optional-rpms"'
+        .format(os_version))
 
     # Install required packages for the installation
     run('yum install -y satellite')


### PR DESCRIPTION
Fix repo_install as RHEL6 has also optional channel available
(...if optional is not available then entitlements are about to fix)

(Issue #416)