### PR TITLE
Fix for making firewall persistent across reboot for RHEL6

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -415,7 +415,8 @@ def setup_firewall(definitions=None, flush=True):
 
     if os_version < 7:
         # To make the changes persistent across reboots
-        run('iptables-save > /etc/sysconfig/iptables')
+        manage_daemon('save', 'iptables')
+        manage_daemon('enable', 'iptables')
     else:
         # To activate persistent settings as the current ones
         run('firewall-cmd --reload')


### PR DESCRIPTION
a) We never had firewall persistent across reboot for RHEL6
b) We were just saving the firewall rules.
c) iptables service was never set to start at boot time.
d) With this fix, we can now save the iptables using he service
   command and also enable it too.
