### PR TITLE
Fix repo_install() to enable rhel-6-server-optional-rpms

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1113,11 +1113,8 @@ def repofile_install(admin_password=None, run_katello_installer=True,
     run('wget -O /etc/yum.repos.d/satellite63.repo {0}'.format(repo_url))
 
     # Enable required repository
-    if os_version >= 7:
-        run(
-            'subscription-manager repos --enable '
-            '"rhel-{0}-server-optional-rpms"'.format(os_version)
-        )
+    run('subscription-manager repos --enable rhel-{0}-server-optional-rpms'
+        .format(os_version))
 
     # Install required packages for the installation
     run('yum install -y satellite')


### PR DESCRIPTION
Fix repo_install() to enable rhel-6-server-optional-rpms

- fix missing dependecy for syslinux-extlinux on rhel6

(Issue #440)