### PR TITLE
Unify *_install() methods

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -41,6 +41,7 @@ from automation_tools import (  # flake8: noqa
     setup_proxy,
     setup_vm_provisioning,
     subscribe,
+    subscribe_dogfood,
     unsubscribe,
     update_basic_packages,
     update_rhsm_stage,


### PR DESCRIPTION
Unify *_install() methods
- unifies somewhat different ak_install() with other installs
- new subscribe_dogfood() used by ak_install()
- reorders various executes (silence yum, os update, os upgrade repo)

(Issue #445)