### PR TITLE
Handle mounting of the right ISO file.

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1279,7 +1279,7 @@ def iso_install(
 
     # Create a 'check-out' folder, mount ISO to it...
     run('mkdir -p ~/ISO')
-    run('mount *.iso ~/ISO -t iso9660 -o loop')
+    run('mount *dvd1.iso ~/ISO -t iso9660 -o loop')
     # ...and run the installer script.
     with cd('~/ISO'):
         if check_gpg_signatures is True:


### PR DESCRIPTION
a) Some URL paths also have live iso files, which would cause
   issues, due to multiple iso file matches.
b) This fix should pick only a single ISO file.