### PR TITLE
Check Satellite Version instead of Upgrading again

### DIFF
--- a/automation_tools/satellite6/upgrade/__init__.py
+++ b/automation_tools/satellite6/upgrade/__init__.py
@@ -21,6 +21,9 @@ from automation_tools.satellite6.upgrade.satellite import (
     satellite6_upgrade,
     satellite6_zstream_upgrade
 )
+from automation_tools.satellite6.upgrade.tasks import (
+    get_sat_version
+)
 from fabric.api import execute
 
 
@@ -164,7 +167,10 @@ def product_upgrade(product):
             product, os.environ.get('OS'))
         with LogAnalyzer(sat_host):
             if from_version != to_version:
-                execute(satellite6_upgrade, host=sat_host)
+                current_version = execute(
+                    get_sat_version, host=sat_host)
+                if not current_version == to_version:
+                    execute(satellite6_upgrade, host=sat_host)
             elif from_version == to_version:
                 execute(satellite6_zstream_upgrade, host=sat_host)
             # Generate foreman debug on satellite after upgrade

--- a/fabfile.py
+++ b/fabfile.py
@@ -84,6 +84,7 @@ from automation_tools.satellite6.upgrade.tasks import (
     delete_rhevm_instance,
     docker_execute_command,
     generate_satellite_docker_clients_on_rhevm,
+    get_sat_version,
     refresh_subscriptions_on_docker_clients,
     remove_all_docker_containers,
     sync_capsule_repos_to_upgrade,


### PR DESCRIPTION
This PR has following additions and updates:
1. New functions for discovering the current satellite version
2. Updates in process of upgrade if current_version is same as To_Version then upgrade on satellite will not be performed.
3. Capsule Upgrade can now be upgraded later(change in tasks.py) after Satellite upgrade.