### PR TITLE
Attemp #2 to mitigate "Error: INVALID_ZONE"

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -449,8 +449,11 @@ def setup_firewall(definitions=None, flush=True):
             run('systemctl start firewalld')
         # FIXME attempt to mitigate "Error: INVALID_ZONE"
         for i in range(5):
-            if run('firewall-cmd --list-all-zones', warn_only=True).succeeded:
+            if run(
+                'firewall-cmd --permanent --list-all-zones', warn_only=True
+            ).succeeded:
                 break
+            run('systemctl restart firewalld')
             time.sleep((i+1) * 5)
 
         exists_command = 'firewall-cmd --permanent --query-port="{1}/{0}"'


### PR DESCRIPTION
Attemp No.2 to mitigate "Error: INVALID_ZONE"
- check for permanent zones (--permanent) since we check/modify the permanent ones
- restart firewalld service and wait (mere waiting doesn't help)