### PR TITLE
Nightly has --capsule-puppet renamed to --foreman-proxy-puppet

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -338,6 +338,10 @@ def setup_default_capsule(interface=None, run_katello_installer=True):
         proxy = 'capsule'
     else:
         proxy = 'foreman-proxy'
+    if os.environ.get('SATELLITE_VERSION') in ('6.0', '6.1', '6.2', '6.3'):
+        proxypuppet = 'capsule'
+    else:
+        proxypuppet = 'foreman-proxy'
 
     installer_options = {
         '{0}-dns'.format(proxy): 'true',
@@ -348,7 +352,7 @@ def setup_default_capsule(interface=None, run_katello_installer=True):
         '{0}-dhcp-interface'.format(proxy): interface,
         '{0}-tftp'.format(proxy): 'true',
         '{0}-tftp-servername'.format(proxy): hostname,
-        'capsule-puppet': 'true',
+        '{0}-puppet'.format(proxypuppet): 'true',
         '{0}-puppetca'.format(proxy): 'true',
         '{0}-register-in-foreman'.format(proxy): 'true',
     }


### PR DESCRIPTION
Transition to foreman-proxy named options was done gradually,
thus we need more proxy* vars and more ifs setting them appropriately