### PR TITLE
Fix reboot in Personal Satellite zStream upgrade

### DIFF
--- a/automation_tools/satellite6/upgrade/satellite.py
+++ b/automation_tools/satellite6/upgrade/satellite.py
@@ -203,13 +203,14 @@ def satellite6_zstream_upgrade():
     update_packages(quiet=False)
     print('YUM UPDATE finished at: {0}'.format(time.ctime()))
     # Rebooting the system to check the possible issues if kernal is updated
-    reboot(120)
-    if to_version == '6.1':
-        # Stop the service again which started in restart
-        # This step is not required with 6.2 upgrade as installer itself
-        # stop all the services before upgrade
-        run('katello-service stop')
-        run('service-wait mongod start')
+    if os.environ.get('RHEV_SAT_HOST'):
+        reboot(120)
+        if to_version == '6.1':
+            # Stop the service again which started in restart
+            # This step is not required with 6.2 upgrade as installer itself
+            # stop all the services before upgrade
+            run('katello-service stop')
+            run('service-wait mongod start')
     # Running Upgrade
     print('SATELLITE UPGRADE started at: {0}'.format(time.ctime()))
     if to_version == '6.1':


### PR DESCRIPTION
This PR fix the personal Satellite Upgrade for zStream builds.

Fix:
Ideally we dont reboot personal satellite/capsules during upgrade due to its unknown environment and configuration due to which we cant provide timeout for reboot. So currently only our RHEVM satellite/capsule are eligible for reboots.