### PR TITLE
Move fake capsule port range to avoid conflict with foreman-selinux

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2335,7 +2335,7 @@ def set_service_check_status(user='admin', password='changeme',
     )
 
 
-def setup_alternate_capsule_ports(port_range='9091-14999'):
+def setup_alternate_capsule_ports(port_range='9400-14999'):
     """Setup alternate capsule ports in SELINUX and install tunneling tool
 
     :param port_range: these ports will be added under websm_port_t type.


### PR DESCRIPTION
Satellite 6.1 foreman-selinux defines port range 9200-9300 for elasticsearch
This range is conflicting with our custom fake capsule port range 9091-14999.

This PR brings change that avoid this conflict.
```
libsemanage.semanage_port_validate_local: port overlap between ranges 9200 - 9300 (tcp) <--> 9091 - 14999 (tcp). (No such file or directory).
OSError: No such file or directory
```
(Moving for all Satellite versions so it stays simple)

