### PR TITLE
[Upgrade] Fix promote CV version to Dev in Sat 6.2 closes #490

### DIFF
--- a/automation_tools/satellite6/hammer.py
+++ b/automation_tools/satellite6/hammer.py
@@ -246,17 +246,21 @@ def hammer_content_view_publish(name, organization_id):
 
 @task
 def hammer_content_view_promote_version(
-        cv_name, cv_ver_id, lc_env_id, organization_id):
+        cv_name, cv_ver_id, lc_env_id, organization_id, sat61plus=True):
     """Promotes a content view version
 
     :param cv_name: name of the content view which will be published
     :param cv_ver_id: CV Version id to be promoted
     :param lc_env_id: LC Environment id onto which cv version to be promoted
     :param organization_id: organization where the content view was created
+    :param sat61plus: lc choosing option to promote the CV is different in
+        Sat 6.1+ versions
     """
+    lc_promote_opt = 'to-lifecycle-environment-id' if sat61plus else \
+        'lifecycle-environment-id'
     return hammer('content-view version promote --content-view {0} --id {1} '
-                  '--lifecycle-environment-id {2} --organization-id 1'
-                  .format(cv_name, cv_ver_id, lc_env_id))
+                  '--{2} {3} --organization-id 1'.format(
+                    cv_name, cv_ver_id, lc_promote_opt, lc_env_id))
 
 
 @task

--- a/automation_tools/satellite6/upgrade/tasks.py
+++ b/automation_tools/satellite6/upgrade/tasks.py
@@ -449,7 +449,8 @@ def sync_capsule_repos_to_upgrade(capsules):
         cv_ver_id = get_attribute_value(cv_version_data, '{0} {1}'.format(
             cv_name, latest_cv_ver), 'id')
         hammer_content_view_promote_version(
-            cv_name, cv_ver_id, lc_env_id, '1')
+            cv_name, cv_ver_id, lc_env_id, '1',
+            False if from_version == '6.0' else True)
         if capsule_repo:
             hammer_activation_key_add_subscription(
                 activation_key, '1', product_name)


### PR DESCRIPTION
Promoting CV version to DEV was broking due to changed option of '--to-lifecycle-environent-id' in Sat 6.1 and SAt 6.2 and the error was thrown for passing option to promote a CV.

The error was as below:
```
Could not promote the content view:
Error: Unrecognised option '--lifecycle-environment-id'
          See: 'hammer content-view version promote --help'
```
This PR fixes this issue and passes the correct option according to Sat version.