### PR TITLE
Start docker.service with warn_only=True

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -280,7 +280,8 @@ def setup_default_docker():
 
     # enable the service as it is disabled by default on RHEL7
     manage_daemon('enable', 'docker', pty=(os_version >= 7))
-    manage_daemon('restart', 'docker', pty=(os_version >= 7))
+    manage_daemon('restart', 'docker', pty=(os_version >= 7),
+                  warn_only=bz_bug_is_open('1414821'))
 
 
 def setup_default_capsule(interface=None, run_katello_installer=True):


### PR DESCRIPTION
Start docker.service with warn_only=True
Docker 1.12 service fails to start, as a result the whole provisioning/installation job fails.

