### PR TITLE
Fix the capital case issue with hostname

### DIFF
--- a/automation_tools/satellite6/upgrade/tasks.py
+++ b/automation_tools/satellite6/upgrade/tasks.py
@@ -500,7 +500,7 @@ def generate_satellite_docker_clients_on_rhevm(client_os, clients_count):
     ak = os.environ.get('RHEV_CLIENT_AK_{}'.format(client_os.upper()))
     result = {}
     for count in range(int(clients_count)):
-        hostname = '{0}DockerClient{1}'.format(count, client_os)
+        hostname = '{0}dockerclient{1}'.format(count, client_os)
         container_id = run(
             'docker run -d -h {0} -v /dev/log:/dev/log -e "SATHOST={1}" '
             '-e "AK={2}" upgrade:{3}'.format(


### PR DESCRIPTION
We faced an issue while attaching custom product of latest tools repo(for upgrade) to the host created on docker. Because host was not identified to run hammer attach command.

Basically It was a capital case issue in docker hostname as below:
We were passing hostname as '0DockerClientrhel7(Please not D and C are capital here)' but the satellite was converting this into 0dockerclientrhel7(Note that D and C is now lower. And we were finding or attaching the subscriptions to the given hostname which is '0DockerClientrhel7' which doesnt exists.

So fixed the same by lowering the hostname while giving itself.

Fixes #493