### PR TITLE
Fix: Upgrading Downstream Satellite to CDN

### DIFF
--- a/automation_tools/satellite6/upgrade/satellite.py
+++ b/automation_tools/satellite6/upgrade/satellite.py
@@ -98,6 +98,10 @@ def satellite6_upgrade():
     if base_url is None:
         enable_repos('rhel-{0}-server-satellite-{1}-rpms'.format(
             major_ver, to_version))
+        # Remove old custom sat repo
+        for fname in os.listdir('/etc/yum.repos.d/'):
+            if 'sat' in fname.lower():
+                os.remove('/etc/yum.repos.d/{}'.format(fname))
     # Else, consider this as Downstream upgrade
     else:
         # Add Sat6 repo from latest compose
@@ -178,6 +182,10 @@ def satellite6_zstream_upgrade():
     if base_url is None:
         enable_repos('rhel-{0}-server-satellite-{1}-rpms'.format(
             major_ver, to_version))
+        # Remove old custom sat repo
+        for fname in os.listdir('/etc/yum.repos.d/'):
+            if 'sat' in fname.lower():
+                os.remove('/etc/yum.repos.d/{}'.format(fname))
     # Else, consider this as Downstream upgrade
     else:
         # Add Sat6 repo from latest compose


### PR DESCRIPTION
Closes #495 .

Lets take an example:

I have Satellite 6.2.5 installed using sat repo, and I want to upgrade this to the latest CDN version(which is 6.2.6).
Now, our Upgrade Automation sets the latest CDN repo but **DOESNT REMOVES** the older custom sat repo and hence upgrade pulls latest downstream packages from custom sat repo. And that will upgrade to 6.2.7 (latest Downstream).

And hence the yum repolist would look like this:
```
!rhel-7-server-rpms/x86_64                                                             Red Hat Enterprise Linux 7 Server (RPMs)                                                                              13,813
!rhel-7-server-satellite-6.2-rpms/x86_64                                               Red Hat Satellite 6.2 (for RHEL 7 Server) (RPMs)                                                                         542
!rhel-server-rhscl-7-rpms/x86_64                                                       Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server                                                7,118
!sat6                                                                                  Satellite 6 
```
Note: There are two sat repos one from CDN and one custom.

So this fix removes that custom repo while upgrading to CDN.