### PR TITLE
Fix upstream_install() as forklift removed setup.rb

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1088,6 +1088,9 @@ def upstream_install(admin_password=None, run_katello_installer=True,
     run('yum install -y git ruby')
     run('rm -rf forklift')
     run('git clone -q https://github.com/Katello/forklift.git')
+    # https://github.com/Katello/forklift/pull/369 removed setup.rb that we use
+    # checkout before the change until we'll know how to proceed the new way
+    run('git checkout -q 336783394283fd15bf6ef29aee5a24917f99dfad')
 
     run('yum -d2 repolist')
     # For now, puppet-four is configured by default. Toggle option


### PR DESCRIPTION
Finally! 
Nightly was fixed by devs.
But at the same time PR https://github.com/Katello/forklift/pull/369 re-factored forklift and removed `setup.rb` that we are using.

```
[10.8.213.1] run: ./setup.rb --skip-installer --puppet-four
[10.8.213.1] out: /bin/bash: ./setup.rb: No such file or directory
[10.8.213.1] out: 

Fatal error: run() received nonzero return code 127 while executing!
```
This PR aims to fix it quickly in order to continue getting nightly automation results.
We just need what worked - to install nightly, nothing special.

Of course that in future we can implement the new way to install nightly devs switched to.
(I asked ehelms for hints)


