### PR TITLE
Fix wrong message of Capsule Upgrade Highlight from 6.1 to 6.2

### DIFF
--- a/automation_tools/satellite6/upgrade/__init__.py
+++ b/automation_tools/satellite6/upgrade/__init__.py
@@ -179,14 +179,14 @@ def product_upgrade(product):
             product, os.environ.get('OS'))
         try:
             with LogAnalyzer(sat_host):
-                current = str(execute(
-                    get_sat_cap_version, 'sat', host=sat_host)[sat_host])
+                current = execute(
+                    get_sat_cap_version, 'sat', host=sat_host)[sat_host]
                 if from_version != to_version:
                     execute(satellite6_upgrade, host=sat_host)
                 else:
                     execute(satellite6_zstream_upgrade, host=sat_host)
-                upgraded = str(execute(
-                    get_sat_cap_version, 'sat', host=sat_host)[sat_host])
+                upgraded = execute(
+                    get_sat_cap_version, 'sat', host=sat_host)[sat_host]
                 if LooseVersion(upgraded) > LooseVersion(current):
                     logger.highlight(
                         'The Satellite is upgraded from {0} to {1}'.format(
@@ -202,18 +202,18 @@ def product_upgrade(product):
                     for cap_host in cap_hosts:
                         try:
                             with LogAnalyzer(cap_host):
-                                current = str(execute(
+                                current = execute(
                                     get_sat_cap_version, 'cap', host=cap_host
-                                    )[cap_host])
+                                    )[cap_host]
                                 if from_version != to_version:
                                     execute(satellite6_capsule_upgrade,
                                             cap_host, host=cap_host)
                                 elif from_version == to_version:
                                     execute(satellite6_capsule_zstream_upgrade,
                                             host=cap_host)
-                                upgraded = str(execute(
+                                upgraded = execute(
                                     get_sat_cap_version, 'cap', host=cap_host
-                                    )[cap_host])
+                                    )[cap_host]
                                 if current:
                                     if LooseVersion(upgraded) > LooseVersion(
                                             current):

--- a/automation_tools/satellite6/upgrade/client.py
+++ b/automation_tools/satellite6/upgrade/client.py
@@ -197,7 +197,7 @@ def satellite6_client_upgrade(os_version, clients):
         performed
     """
     logger.highlight(
-        '\n========== CLIENT UPGRADE : {} =================\n'.format(
+        '\n========== {} CLIENTS UPGRADE =================\n'.format(
             os_version.upper()))
     old_version = os.environ.get('FROM_VERSION')
     docker_vm = os.environ.get('DOCKER_VM')

--- a/automation_tools/satellite6/upgrade/tasks.py
+++ b/automation_tools/satellite6/upgrade/tasks.py
@@ -695,7 +695,7 @@ def _extract_sat_cap_version(command):
         if result:
             version = result.group('version')
             return version, cmd_result
-    return 'Unavailable', cmd_result
+    return None, cmd_result
 
 
 def get_sat_cap_version(product):
@@ -717,8 +717,8 @@ def get_sat_cap_version(product):
         (_6_2_VERSION_COMMAND, _LT_6_2_VERSION_COMMAND)
     )
     for version, cmd_result in results:
-        if version != 'Unavailable':
+        if version:
             return version
-    logger.error('Error in detecting installed version due to:\n{}'.format(
+    logger.warning('Unable to detect installed version due to:\n{}'.format(
         cmd_result
     ))


### PR DESCRIPTION
This PR:

1. Wrong message for Capsule Upgrade appeared for 6.1 to 6.2 upgrade, saying the capsule is not upgraded but the capsule is actually upgraded. Closes #519 
2. Modified 'CLIENT UPGRADE: <rhel_version>' to '<rhel_version> CLIENTS Upgrade' for better meaning of rhel7 and rhel6 clients.
3. get_Sat_cap_ver function modifeid to return None with reason if no version found.