### PR TITLE
Fix the logger level name issue that fails upgrade job

### DIFF
--- a/automation_tools/satellite6/upgrade/__init__.py
+++ b/automation_tools/satellite6/upgrade/__init__.py
@@ -227,7 +227,7 @@ def product_upgrade(product):
                                             'next version. Now its {}'.format(
                                                 upgraded))
                                 else:
-                                    logger.hightlight(
+                                    logger.highlight(
                                         'Unable to fetch previous version but '
                                         'after upgrade capsule is {}.'.format(
                                             upgraded))


### PR DESCRIPTION
Fix the misspelling of logger level 'highlight' that failed the entire upgrade job.