### PR TITLE
Remove the warn_only is true value for cleanup_idm task.

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1754,8 +1754,7 @@ def product_install(distribution, create_vm=False, certificate_url=None,
         execute(
             cleanup_idm,
             hostname=sat6_hostname,
-            host=idm_server_ip,
-            warn_only=True
+            host=idm_server_ip
         )
         execute(enroll_idm, host=host)
     if os.environ.get('IDM_EXTERNAL_AUTH') == 'true':


### PR DESCRIPTION
Guys, this was a typo and this issue will fix the current failure we face due to it .

```
[10.x.x.x] Executing task 'cleanup_idm'
Traceback (most recent call last):
  File "/home/jenkins/shiningpanda/jobs/5c6951c7/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/main.py", line 756, in main
    *args, **kwargs
  File "/home/jenkins/shiningpanda/jobs/5c6951c7/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 386, in execute
    multiprocessing
  File "/home/jenkins/shiningpanda/jobs/5c6951c7/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 276, in _execute
    return task.run(*args, **kwargs)
  File "/home/jenkins/shiningpanda/jobs/5c6951c7/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 173, in run
    return self.wrapped(*args, **kwargs)
  File "/home/jenkins/workspace/satellite6-libvirt-install/automation_tools/__init__.py", line 1758, in product_install
    warn_only=True
  File "/home/jenkins/shiningpanda/jobs/5c6951c7/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 386, in execute
    multiprocessing
  File "/home/jenkins/shiningpanda/jobs/5c6951c7/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 276, in _execute
    return task.run(*args, **kwargs)
  File "/home/jenkins/shiningpanda/jobs/5c6951c7/virtualenvs/d41d8cd9/lib/python2.7/site-packages/fabric/tasks.py", line 173, in run
    return self.wrapped(*args, **kwargs)
TypeError: cleanup_idm() got an unexpected keyword argument 'warn_only'
```