### PR TITLE
Fix annoying yum lock already taken issue in client upgrade

### DIFF
--- a/automation_tools/satellite6/upgrade/client.py
+++ b/automation_tools/satellite6/upgrade/client.py
@@ -174,12 +174,12 @@ def satellite6_client_setup():
                 host=sat_host
             )
         # Refresh subscriptions on clients
-        time.sleep(5)
+        time.sleep(30)
         execute(
             refresh_subscriptions_on_docker_clients,
             clients6.values(),
             host=docker_vm)
-        time.sleep(5)
+        time.sleep(30)
         execute(
             refresh_subscriptions_on_docker_clients,
             clients7.values(),


### PR DESCRIPTION
Fix issue mentioned in subject by increasing the sleep time by the time yum locks on all clients will be free.

We will see how this goes, if this doesnt works we may have to wait until yum unlocks on each client or kill yum process.