### PR TITLE
dns-id is not associated at this stage.

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1225,8 +1225,6 @@ def configure_realm(admin_password=None, keytab_url=None, realm=None,
     run('cp /etc/ipa/ca.crt /etc/pki/ca-trust/source/anchors/ipa.crt')
     run('update-ca-trust enable ; update-ca-trust')
     run('service foreman-proxy restart')
-    run('hammer -u admin -p {0} domain update --id 1 --dns-id ""'
-        .format(admin_password))
 
 
 def upstream_install(admin_password=None, run_katello_installer=True,


### PR DESCRIPTION
This is not required in automation-tools as this exact task is performed much later using the satellite6-populate job, https://github.com/SatelliteQE/robottelo-ci/blob/master/scripts/satellite6-populate-template.sh#L230