### PR TITLE
IDM and AD EXTERNAL_AUTH are now mutually exclusive

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1865,7 +1865,7 @@ def product_install(distribution, create_vm=False, certificate_url=None,
             host=host
         )
     if (
-        os.environ.get('IDM_EXTERNAL_AUTH') == 'true' or
+        os.environ.get('EXTERNAL_AUTH') == 'IDM' or
         os.environ.get('IDM_REALM') == 'true'
     ):
         sat6_hostname = os.environ.get('SERVER_HOSTNAME')
@@ -1876,11 +1876,11 @@ def product_install(distribution, create_vm=False, certificate_url=None,
             host=idm_server_ip
         )
         execute(enroll_idm, host=host)
-    if os.environ.get('IDM_EXTERNAL_AUTH') == 'true':
+    if os.environ.get('EXTERNAL_AUTH') == 'IDM':
         execute(configure_idm_external_auth, host=host)
     if os.environ.get('IDM_REALM') == 'true':
         execute(configure_realm, host=host)
-    if os.environ.get('AD_EXTERNAL_AUTH') == 'true':
+    if os.environ.get('EXTERNAL_AUTH') == 'AD':
         execute(enroll_ad, host=host)
         execute(configure_ad_external_auth, host=host)
 


### PR DESCRIPTION
Earlier IDM_EXTERNAL_AUTH and AD_EXTERNAL_AUTH were boolean values
and both could be selected. Where as only one can be selected as
they are mutually exclusive and the only way to get EXTERNAL_AUTH
work with both of them is by establishing CROSS-REALM TRUST
between them.