### PR TITLE
Clients from_version calculation is removed in upgrade logging

### DIFF
--- a/automation_tools/satellite6/upgrade/client.py
+++ b/automation_tools/satellite6/upgrade/client.py
@@ -40,15 +40,12 @@ def personal_clients_upgrade(old_repo, clients):
         will be updated
     """
     for client in clients:
-        pre = katello_agent_version_filter(execute(
-            lambda: run('rpm -q katello-agent'), host=client)[client])
         execute(disable_repos, old_repo, host=client)
         execute(lambda: run('yum update -y katello-agent'), host=client)
         post = katello_agent_version_filter(execute(
             lambda: run('rpm -q katello-agent'), host=client)[client])
         logger.highlight(
-            'katello-agent on {0} upgraded from {1} to {2}'.format(
-                client, pre, post))
+            'katello-agent on {0} upgraded to {1}'.format(client, post))
 
 
 def docker_clients_upgrade(old_repo, clients):
@@ -62,8 +59,6 @@ def docker_clients_upgrade(old_repo, clients):
     for hostname, container in clients.items():
         logger.info('Upgrading client {0} on docker container: {1}'.format(
             hostname, container))
-        pre = katello_agent_version_filter(
-            docker_execute_command(container, 'rpm -q katello-agent'))
         docker_execute_command(
             container, 'subscription-manager repos --disable {}'.format(
                 old_repo))
@@ -71,8 +66,7 @@ def docker_clients_upgrade(old_repo, clients):
         pst = katello_agent_version_filter(
             docker_execute_command(container, 'rpm -q katello-agent'))
         logger.highlight(
-            'katello-agent on {0} upgraded from {1} to {2}'.format(
-                hostname, pre, pst))
+            'katello-agent on {0} upgraded to {1}'.format(hostname, pst))
 
 
 def satellite6_client_setup():


### PR DESCRIPTION
Removed calculation of clients from_version or previous version in logging.

Reason: The race condition is throwing to_version as from_version during client upgrade task. Which is giving wrong status of client upgrade.

Impact: This will not have any impact on client upgrade or logging. Only the previos version of client (katello-agent) wont be displayed in Upgrade status Email. This is absolutely low severity removal of code.