### PR TITLE
Fix paramiko logging handler issue

### DIFF
--- a/automation_tools/satellite6/upgrade/tools.py
+++ b/automation_tools/satellite6/upgrade/tools.py
@@ -56,6 +56,8 @@ def logger():
     """
     logging.setLoggerClass(MyLogger)
     log = logging.getLogger('upgrade_logging')
+    paramiko_logger = logging.getLogger("paramiko.transport")
+    paramiko_logger.disabled = True
     if not log.handlers:
         # Log files
         logfile_path = os.path.abspath('full_upgrade')


### PR DESCRIPTION
We were getting paramiko errors while running fab tasks.

The error was something like this:
```
No handlers could be found for logger "paramiko.transport"

```

I disable the paramiko logging which wont impact on our upgrade.