### PR TITLE
unlock discovery snippet first before updating it

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -707,6 +707,10 @@ def setup_foreman_discovery(sat_version):
     run('hammer -u admin -p {0} template update '
         '--name "PXELinux global default" --locked "false"'
         .format(admin_password))
+    # Unlock the 'pxelinux_discovery' snippet
+    run('hammer -u admin -p {0} template update '
+        '--name "pxelinux_discovery" --type "snippet" --locked "false"'
+        .format(admin_password))
     # Fetch the updated template where ONTIMEOUT set to 'discovery'
     # Note that this template is for discovery7.0
     template_url = os.environ.get('PXE_DEFAULT_TEMPLATE_URL_FOR_70')


### PR DESCRIPTION
nightly install failing while discovery_setup because `pxelinux_discovery` snippet is locked now. So need to first unlock it before making any change there.

```console
[root@qe-nightly-rhel7 ~]# hammer -u admin -p changeme template update --name "pxelinux_discovery" --locked=false --type=snippet
Provisioning template updated
[root@qe-nightly-rhel7 ~]# hammer -u admin -p changeme template info --id 74
Id:                74
Name:              pxelinux_discovery
Type:              snippet
Locked:            no
Operating systems: 

Locations:         
    Default Location
Organizations:     
    Default Organization
```