### PR TITLE
Yum lock issue fix by killing PID

### DIFF
--- a/automation_tools/satellite6/upgrade/client.py
+++ b/automation_tools/satellite6/upgrade/client.py
@@ -135,16 +135,12 @@ def satellite6_client_setup():
             int(clients_count)/2,
             host=docker_vm
         )[docker_vm]
-        # Adding sleep to freed up yum lock taken by above client generate task
-        time.sleep(30)
         clients7 = execute(
             generate_satellite_docker_clients_on_rhevm,
             'rhel7',
             int(clients_count)/2,
             host=docker_vm
         )[docker_vm]
-        # Adding sleep to freed up yum lock taken by above client generate task
-        time.sleep(30)
         # Sync latest sat tools repo to clients if downstream
         if all([
             os.environ.get('TOOLS_URL_RHEL6'),


### PR DESCRIPTION
In docker containers, due to multiple reasons the yum service was not been freed up to make it available for mext task. Due to which the client upgrade is failing while attempting to update katello-agent package.

So fixing this issue by killing this yum.pid before using the yum.

Also removing the earlier workaround of hard sleep times.