### PR TITLE
Enable satellite6 package to be accessible with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author=u'Elyézer Rezende',
     author_email='erezende@redhat.com',
     url='https://github.com/SatelliteQE/automation-tools',
-    packages=['automation_tools'],
+    packages=['automation_tools', 'automation_tools/satellite6'],
     package_data={'': ['LICENSE']},
     package_dir={'automation_tools': 'automation_tools'},
     include_package_data=True,


### PR DESCRIPTION
Currently only automation_tools package is listed to be accessible via pip.

This PR enables satellite6 package under automation_tools package to accessible via pip install.

This resolves the dependency issue with https://github.com/SatelliteQE/satellite6-upgrade.