### PR TITLE
keep the template files on disk

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -751,7 +751,6 @@ def setup_foreman_discovery(sat_version):
         run('hammer -u admin -p {0} template update --name '
             '"PXELinux global default" --file {1}'
             .format(admin_password, template_file))
-        run('rm -rf {0}'.format(template_file))
         return
 
     if sat_version == 'upstream-nightly':
@@ -785,7 +784,6 @@ def setup_foreman_discovery(sat_version):
     run('hammer -u admin -p {0} template update --name '
         '"pxelinux_discovery" --type "snippet" --file {1}'
         .format(admin_password, snippet_file))
-    run('rm -rf {0}'.format(snippet_file))
     template_file = run('mktemp')
     # Dump the template
     run('hammer -u admin -p {0} template dump --name '
@@ -799,7 +797,6 @@ def setup_foreman_discovery(sat_version):
     run('hammer -u admin -p {0} template update --name '
         '"PXELinux global default" --type "PXELinux" --file {1}'
         .format(admin_password, template_file))
-    run('rm -rf {0}'.format(template_file))
 
 
 def enable_ostree(sat_version='6.3'):


### PR DESCRIPTION
hammer upload command finishes prematurely. This was causing that we used to remove the template files while the upload tas was still running.

```
run: hammer -u admin -p changeme template update --name "PXELinux global default" --file /tmp/tmp.UiTUgxSSnK
out: Config template updated
out: 
Fatal error: put() encountered an exception while uploading '<StringIO.StringIO instance at 0x7f1696316bd8>'
Underlying exception:
No such file
Aborting.
```