### PR TITLE
Setup code coverage to run only for provisioning jobs.

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1995,7 +1995,9 @@ def product_install(distribution, create_vm=False, certificate_url=None,
             sat_version=satellite_version,
             host=host
         )
-    execute(setup_code_coverage, host=host)
+    # Setup code_coverage only for the provisoning jobs.
+    if 'base' in target_image:
+        execute(setup_code_coverage, host=host)
     if (
         os.environ.get('EXTERNAL_AUTH') == 'IDM' or
         os.environ.get('IDM_REALM') == 'true'


### PR DESCRIPTION
This is done, so that code_coverage is not configured while
configuring a setup via the satellite6 installer job.