### PR TITLE
Fix typo: s/upstream-nightly/nightly/

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2666,7 +2666,7 @@ def katello_installer(debug=False, distribution=None, verbose=True,
         installer,
         '--scenario {0}'
         .format(scenario) if sat_version in (
-            '6.2', '6.3', 'upstream-nightly', 'downstream-nightly'
+            '6.2', '6.3', 'nightly', 'downstream-nightly'
         ) else '',
         '-d' if debug else '',
         '-v' if verbose else '',


### PR DESCRIPTION
Fixes upstream provisioning failure:
```
[server] out: ERROR: No installation scenario was selected, the installer cannot continue.
[server] out:        Even --help content is dependent on selected scenario.
[server] out:        Select scenario with --scenario SCENARIO or list available scenarios with --list-scenarios.
[server] out: 

Fatal error: run() received nonzero return code 26 while executing!
```
