### PR TITLE
Pin paramiko==2.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     install_requires=[
         'Fabric',
         'lxml',
+        'paramiko==2.1.2',
         'pycurl',
         'pytest',
         'python-bugzilla==1.2.2',


### PR DESCRIPTION
```paramiko-2.2.0``` has new dependency ```pynacl```
Collecting pynacl>=1.0.1 (from paramiko<3.0,>=1.10->Fabric->automation-tools->-r requirements.txt (line 6))
  Using cached PyNaCl-1.1.2.tar.gz

And pynacl fails to build:
```
Building wheels for collected packages: pynacl
  Running setup.py bdist_wheel for pynacl: started
  Running setup.py bdist_wheel for pynacl: finished with status 'error'
  Complete output from command /home/jenkins/shiningpanda/jobs/f215f424/virtualenvs/d41d8cd9/bin/python2.7 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-CEa2pP/pynacl/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmp326mHRpip-wheel- --python-tag cp27:
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-2.7
  creating build/lib.linux-x86_64-2.7/nacl
  copying src/nacl/utils.py -> build/lib.linux-x86_64-2.7/nacl
  copying src/nacl/signing.py -> build/lib.linux-x86_64-2.7/nacl
  copying src/nacl/secret.py -> build/lib.linux-x86_64-2.7/nacl
  copying src/nacl/pwhash.py -> build/lib.linux-x86_64-2.7/nacl
  copying src/nacl/public.py -> build/lib.linux-x86_64-2.7/nacl
  copying src/nacl/hashlib.py -> build/lib.linux-x86_64-2.7/nacl
  copying src/nacl/hash.py -> build/lib.linux-x86_64-2.7/nacl
  copying src/nacl/exceptions.py -> build/lib.linux-x86_64-2.7/nacl
  copying src/nacl/encoding.py -> build/lib.linux-x86_64-2.7/nacl
  copying src/nacl/__init__.py -> build/lib.linux-x86_64-2.7/nacl
  creating build/lib.linux-x86_64-2.7/nacl/bindings
  copying src/nacl/bindings/utils.py -> build/lib.linux-x86_64-2.7/nacl/bindings
  copying src/nacl/bindings/sodium_core.py -> build/lib.linux-x86_64-2.7/nacl/bindings
  copying src/nacl/bindings/randombytes.py -> build/lib.linux-x86_64-2.7/nacl/bindings
  copying src/nacl/bindings/crypto_sign.py -> build/lib.linux-x86_64-2.7/nacl/bindings
  copying src/nacl/bindings/crypto_shorthash.py -> build/lib.linux-x86_64-2.7/nacl/bindings
  copying src/nacl/bindings/crypto_secretbox.py -> build/lib.linux-x86_64-2.7/nacl/bindings
  copying src/nacl/bindings/crypto_scalarmult.py -> build/lib.linux-x86_64-2.7/nacl/bindings
  copying src/nacl/bindings/crypto_pwhash.py -> build/lib.linux-x86_64-2.7/nacl/bindings
  copying src/nacl/bindings/crypto_hash.py -> build/lib.linux-x86_64-2.7/nacl/bindings
  copying src/nacl/bindings/crypto_generichash.py -> build/lib.linux-x86_64-2.7/nacl/bindings
  copying src/nacl/bindings/crypto_box.py -> build/lib.linux-x86_64-2.7/nacl/bindings
  copying src/nacl/bindings/__init__.py -> build/lib.linux-x86_64-2.7/nacl/bindings
  running build_clib
  checking build system type... x86_64-unknown-linux-gnu
  checking host system type... x86_64-unknown-linux-gnu
  checking for a BSD-compatible install... /usr/bin/install -c
  checking whether build environment is sane... yes
  checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
  checking for gawk... gawk
  checking whether make sets $(MAKE)... yes
  checking whether make supports nested variables... yes
  checking whether UID '1001' is supported by ustar format... yes
  checking whether GID '1001' is supported by ustar format... yes
  checking how to create a ustar tar archive... gnutar
  checking whether make supports nested variables... (cached) yes
  checking whether to enable maintainer-specific portions of Makefiles... no
  checking for style of include used by make... GNU
  checking for gcc... gcc
  checking whether the C compiler works... yes
  checking for C compiler default output file name... a.out
  checking for suffix of executables...
  checking whether we are cross compiling... no
  checking for suffix of object files... o
  checking whether we are using the GNU C compiler... yes
  checking whether gcc accepts -g... yes
  checking for gcc option to accept ISO C89... none needed
  checking whether gcc understands -c and -o together... yes
  checking dependency style of gcc... none
  checking for a sed that does not truncate output... /usr/bin/sed
  checking how to run the C preprocessor... gcc -E
  checking for grep that handles long lines and -e... /usr/bin/grep
  checking for egrep... /usr/bin/grep -E
  checking whether gcc is Clang... no
  checking whether pthreads work with -pthread... yes
  checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
  checking whether more special flags are required for pthreads... no
  checking for PTHREAD_PRIO_INHERIT... yes
  checking for gcc option to accept ISO C99... none needed
  checking dependency style of gcc... none
  checking for ANSI C header files... yes
  checking for sys/types.h... yes
  checking for sys/stat.h... yes
  checking for stdlib.h... yes
  checking for string.h... yes
  checking for memory.h... yes
  checking for strings.h... yes
  checking for inttypes.h... yes
  checking for stdint.h... yes
  checking for unistd.h... yes
  checking minix/config.h usability... no
  checking minix/config.h presence... no
  checking for minix/config.h... no
  checking whether it is safe to define __EXTENSIONS__... yes
  checking for __native_client__ defined... no
  checking for _FORTIFY_SOURCE defined... no
  checking whether C compiler accepts -D_FORTIFY_SOURCE=2... yes
  checking whether C compiler accepts -fvisibility=hidden... yes
  checking whether C compiler accepts -fPIC... yes
  checking whether the linker accepts -fPIC... yes
  checking whether C compiler accepts -fPIE... yes
  checking whether the linker accepts -fPIE... yes
  checking whether the linker accepts -pie... yes
  checking whether C compiler accepts -fno-strict-aliasing... yes
  checking whether C compiler accepts -fno-strict-overflow... yes
  checking whether C compiler accepts -fstack-protector... yes
  checking whether the linker accepts -fstack-protector... yes
  checking whether C compiler accepts -Wwrite-strings... yes
  checking whether C compiler accepts -Wdiv-by-zero... yes
  checking whether C compiler accepts -Wsometimes-uninitialized... no
  checking whether C compiler accepts  -Wall... yes
  checking whether C compiler accepts  -Wall -Wextra... yes
  checking for clang... no
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal -Wformat=2... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wmissing-declarations... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wmissing-declarations -Wmissing-prototypes... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wmissing-declarations -Wmissing-prototypes -Wnested-externs... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-unknown-pragmas... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-unknown-pragmas -Wnormalized=id... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wpointer-arith... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wpointer-arith -Wredundant-decls... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wpointer-arith -Wredundant-decls -Wstrict-prototypes... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wpointer-arith -Wredundant-decls -Wstrict-prototypes -Wswitch-enum... yes
  checking whether C compiler accepts  -Wall -Wextra -Wbad-function-cast -Wcast-align -Wcast-qual -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wpointer-arith -Wredundant-decls -Wstrict-prototypes -Wswitch-enum -Wvariable-decl... no
  checking whether the linker accepts -Wl,-z,relro... yes
  checking whether the linker accepts -Wl,-z,now... yes
  checking whether the linker accepts -Wl,-z,noexecstack... yes
  checking how to print strings... printf
  checking for a sed that does not truncate output... (cached) /usr/bin/sed
  checking for fgrep... /usr/bin/grep -F
  checking for ld used by gcc... /usr/bin/ld
  checking if the linker (/usr/bin/ld) is GNU ld... yes
  checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
  checking the name lister (/usr/bin/nm -B) interface... BSD nm
  checking whether ln -s works... yes
  checking the maximum length of command line arguments... 1572864
  checking how to convert x86_64-unknown-linux-gnu file names to x86_64-unknown-linux-gnu format... func_convert_file_noop
  checking how to convert x86_64-unknown-linux-gnu file names to toolchain format... func_convert_file_noop
  checking for /usr/bin/ld option to reload object files... -r
  checking for objdump... objdump
  checking how to recognize dependent libraries... pass_all
  checking for dlltool... no
  checking how to associate runtime and link libraries... printf %s\n
  checking for ar... ar
  checking for archiver @FILE support... @
  checking for strip... strip
  checking for ranlib... ranlib
  checking command to parse /usr/bin/nm -B output from gcc object... ok
  checking for sysroot... no
  checking for a working dd... /usr/bin/dd
  checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
  checking for mt... no
  checking if : is a manifest tool... no
  checking for dlfcn.h... yes
  checking for objdir... .libs
  checking if gcc supports -fno-rtti -fno-exceptions... no
  checking for gcc option to produce PIC... -fPIC -DPIC
  checking if gcc PIC flag -fPIC -DPIC works... yes
  checking if gcc static flag -static works... no
  checking if gcc supports -c -o file.o... yes
  checking if gcc supports -c -o file.o... (cached) yes
  checking whether the gcc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
  checking dynamic linker characteristics... GNU/Linux ld.so
  checking how to hardcode library paths into programs... immediate
  checking whether stripping libraries is possible... yes
  checking if libtool supports shared libraries... yes
  checking whether to build shared libraries... no
  checking whether to build static libraries... yes
  checking for ar... (cached) ar
  checking for MMX instructions set... checking whether C compiler accepts -mmmx... yes
  yes
  checking whether C compiler accepts -mmmx... (cached) yes
  checking for SSE2 instructions set... checking whether C compiler accepts -msse2... yes
  yes
  checking whether C compiler accepts -msse2... (cached) yes
  checking whether C compiler accepts -msse3... yes
  checking for SSE3 instructions set... yes
  checking whether C compiler accepts -msse3... (cached) yes
  checking whether C compiler accepts -mssse3... yes
  checking for SSSE3 instructions set... yes
  checking whether C compiler accepts -mssse3... (cached) yes
  checking whether C compiler accepts -msse4.1... yes
  checking for SSE4.1 instructions set... yes
  checking whether C compiler accepts -msse4.1... (cached) yes
  checking whether C compiler accepts -mavx... yes
  checking for AVX instructions set... yes
  checking whether C compiler accepts -mavx... (cached) yes
  checking whether C compiler accepts -mavx2... yes
  checking for AVX2 instructions set... yes
  checking whether C compiler accepts -mavx2... (cached) yes
  checking if _mm256_broadcastsi128_si256 is correctly defined... yes
  checking whether C compiler accepts -maes... yes
  checking whether C compiler accepts -mpclmul... yes
  checking for AESNI instructions set and PCLMULQDQ... yes
  checking whether C compiler accepts -maes... (cached) yes
  checking whether C compiler accepts -mpclmul... (cached) yes
  checking sys/mman.h usability... yes
  checking sys/mman.h presence... yes
  checking for sys/mman.h... yes
  checking for inline... inline
  checking whether byte ordering is bigendian... (cached) no
  checking whether __STDC_LIMIT_MACROS is required... no
  checking whether we can use x86_64 asm code... yes
  checking whether we can assemble AVX opcodes... yes
  checking for 128-bit arithmetic... yes
  checking for cpuid instruction... yes
  checking if the .private_extern asm directive is supported... no
  checking if the .hidden asm directive is supported... yes
  checking if weak symbols are supported... yes
  checking if data alignment is required... no
  checking for arc4random... no
  checking for arc4random_buf... no
  checking for mmap... yes
  checking for mlock... yes
  checking for madvise... yes
  checking for mprotect... yes
  checking for explicit_bzero... no
  checking for nanosleep... yes
  checking for posix_memalign... yes
  checking for getpid... yes
  checking if gcc/ld supports -Wl,--output-def... not needed, shared libraries are disabled
  checking that generated files are newer than configure... done
  configure: creating ./config.status
  config.status: error: cannot find input file: `/home/jenkins/workspace/upgrade-to-6.2-rhel6@tmp/config2891386343072214235tmp.in'
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-build-CEa2pP/pynacl/setup.py", line 232, in <module>
      "Programming Language :: Python :: 3.6",
    File "/usr/lib64/python2.7/distutils/core.py", line 151, in setup
      dist.run_commands()
    File "/usr/lib64/python2.7/distutils/dist.py", line 953, in run_commands
      self.run_command(cmd)
    File "/usr/lib64/python2.7/distutils/dist.py", line 972, in run_command
      cmd_obj.run()
    File "/home/jenkins/shiningpanda/jobs/f215f424/virtualenvs/d41d8cd9/lib/python2.7/site-packages/wheel/bdist_wheel.py", line 199, in run
      self.run_command('build')
    File "/usr/lib64/python2.7/distutils/cmd.py", line 326, in run_command
      self.distribution.run_command(command)
    File "/usr/lib64/python2.7/distutils/dist.py", line 972, in run_command
      cmd_obj.run()
    File "/usr/lib64/python2.7/distutils/command/build.py", line 127, in run
      self.run_command(cmd_name)
    File "/usr/lib64/python2.7/distutils/cmd.py", line 326, in run_command
      self.distribution.run_command(command)
    File "/usr/lib64/python2.7/distutils/dist.py", line 972, in run_command
      cmd_obj.run()
    File "/tmp/pip-build-CEa2pP/pynacl/setup.py", line 159, in run
      cwd=build_temp,
    File "/usr/lib64/python2.7/subprocess.py", line 541, in check_call
      raise CalledProcessError(retcode, cmd)
  subprocess.CalledProcessError: Command '['/tmp/pip-build-CEa2pP/pynacl/src/libsodium/configure', '--disable-shared', '--enable-static', '--disable-debug', '--disable-dependency-tracking', '--with-pic', '--prefix', '/tmp/pip-build-CEa2pP/pynacl/build/temp.linux-x86_64-2.7']' returned non-zero exit status 1
  