### PR TITLE
Revert "Pin paramiko==2.1.2"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
     install_requires=[
         'Fabric',
         'lxml',
-        'paramiko==2.1.2',
         'pycurl',
         'pytest',
         'python-bugzilla==1.2.2',


### PR DESCRIPTION
Reverts SatelliteQE/automation-tools#612

No need to pin. Pyup bot already upped paramiko to paramiko-2.2.1 (for robottelo master)

Before this happened I probably had resolved pynacl compile error by logging under jenkins account on sesame/paprika and **manually** updating paramiko (thus compiling pynacl) within specific virtenvs. I had gotten no error about missing file:  ```/home/jenkins/workspace/upgrade-to-6.2-rhel6@tmp/config2891386343072214235tmp.in```