### PR TITLE
Hotfix: lsmod fails in a VM

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -378,7 +378,7 @@ def setup_default_libvirt(bridge=None):
     :param str interface: Network interface name to be used
     """
     run('yum install -y libvirt libvirt-daemon-kvm virt-install qemu-kvm')
-    run('lsmod | grep kvm_')
+    run('lsmod | grep kvm_', warn_only=True)
     run('sed -i \'s/^#*\s*LIBVIRTD_ARGS=.*/LIBVIRTD_ARGS=--listen/\''
         ' /etc/sysconfig/libvirtd')
     run('sed -i \'s/^#*\s*listen_tls\s*=.*/listen_tls = 0/\''


### PR DESCRIPTION
hotfix for:
```
Fatal error: run() received nonzero return code 1 while executing!

Requested: lsmod | grep kvm_
Executed: /bin/bash -l -c "lsmod | grep kvm_"

Aborting.

[server] run: lsmod | grep kvm_
```