### PR TITLE
Allow the partition_disk job to successfully run on RHEL 6

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2115,7 +2115,7 @@ def partition_disk():
     synchronization of larger repositories.
 
     """
-    if run('stat --format=%m /home') == '/home':
+    if run('df -P /home | awk \'END{print $NF}\'') == '/home':
         run('umount /home')
         run('lvremove -f /dev/mapper/*home')
         run("sed -i '/\/home/d' /etc/fstab")


### PR DESCRIPTION
On RHEL 6.8+, the %m format is not available for the stat command.
Switching to this version, which produces the same output, and works
on both RHEL 6 and RHEL 7.

Fixes #618