### PR TITLE
Move fix_qdrouterd_listen_to_ipv6() task after all installer runs

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2046,7 +2046,6 @@ def product_install(distribution, create_vm=False, certificate_url=None,
             certificate_url,
             host=host
         )
-    execute(fix_qdrouterd_listen_to_ipv6, host=host)
     execute(setup_alternate_capsule_ports, host=host)
 
     if distribution.startswith('satellite6'):
@@ -2073,6 +2072,8 @@ def product_install(distribution, create_vm=False, certificate_url=None,
             sat_version=satellite_version,
             host=host
         )
+    execute(fix_qdrouterd_listen_to_ipv6, host=host)
+
     # Setup code_coverage only for the provisoning jobs.
     if 'TARGET_IMAGE' in os.environ and 'base' in target_image:
         execute(setup_code_coverage, host=host)


### PR DESCRIPTION
... so that changes are not overridden by a successive installer run


The task changes were not effective (still listening on ipv4 only) as we are running installer in postinstall time once more (enable_ostree ) since Oct 2016
