### PR TITLE
Fixes the osp_configure method to support 6.2 and 6.3

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -5,6 +5,7 @@ from automation_tools import (  # flake8: noqa
     clean_rhsm,
     cleanup_idm,
     client_registration_test,
+    configure_osp,
     configure_ad_external_auth,
     configure_idm_external_auth,
     configure_realm,


### PR DESCRIPTION
```
SATELLITE_VERSION='6.3' fab -H root@satellie.com configure_osp:"changeme","ospdomain.com","179.0.0 178.0.0 177.0.0 176.0.0"
[root@satellie.com] Executing task 'configure_osp'
[root@satellie.com] run: rm -rf /root/zones_cons.conf
[root@satellie.com] run: rm -rf /root/zones-pre_osp.conf
[root@satellie.com] run: cp /etc/named/zones.conf /root/zones-pre_osp.conf
[root@satellie.com] run: for i in 179.0.0 178.0.0 177.0.0 176.0.0; do satellite-installer --foreman-proxy-dns-reverse $i.in-addr.arpa ; sed -n 1,7p
/etc/named/zones.conf >> /root/zones_cons.conf ; done
Installing             Done                                               [100%] [............................................................................................................]
[root@satellie.com] out:   Success!
[root@satellie.com] out:   * Katello is running at https://satellie.com
[root@satellie.com] out:   * To install an additional Foreman proxy on separate machine continue by running:
[root@satellie.com] out:
[root@satellie.com] out:       foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" --certs-tar "/root/$FOREMAN_PROXY-certs.tar"
[root@satellie.com] out:
[root@satellie.com] out:   The full log is at /var/log/foreman-installer/satellite.log
Installing             Done                                               [100%] [............................................................................................................]
[root@satellie.com] out:   Success!
[root@satellie.com] out:   * Katello is running at https://satellie.com
[root@satellie.com] out:   * To install an additional Foreman proxy on separate machine continue by running:
[root@satellie.com] out:
[root@satellie.com] out:       foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" --certs-tar "/root/$FOREMAN_PROXY-certs.tar"
[root@satellie.com] out:
[root@satellie.com] out:   The full log is at /var/log/foreman-installer/satellite.log
Installing             Done                                               [100%] [............................................................................................................]
[root@satellie.com] out:   Success!
[root@satellie.com] out:   * Katello is running at https://satellie.com
[root@satellie.com] out:   * To install an additional Foreman proxy on separate machine continue by running:
[root@satellie.com] out:
[root@satellie.com] out:       foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" --certs-tar "/root/$FOREMAN_PROXY-certs.tar"
[root@satellie.com] out:
[root@satellie.com] out:   The full log is at /var/log/foreman-installer/satellite.log
Installing             Done                                               [100%] [............................................................................................................]
[root@satellie.com] out:   Success!
[root@satellie.com] out:   * Katello is running at https://satellie.com
[root@satellie.com] out:   * To install an additional Foreman proxy on separate machine continue by running:
[root@satellie.com] out:
[root@satellie.com] out:       foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" --certs-tar "/root/$FOREMAN_PROXY-certs.tar"
[root@satellie.com] out:
[root@satellie.com] out:   The full log is at /var/log/foreman-installer/satellite.log
[root@satellie.com] out:

[root@satellie.com] run: satellite-installer --foreman-proxy-dns-zone ospdomain.com
Installing             Done                                               [100%] [............................................................................................................]
[root@satellie.com] out:   Success!
[root@satellie.com] out:   * Katello is running at https://satellie.com
[root@satellie.com] out:   * To install an additional Foreman proxy on separate machine continue by running:
[root@satellie.com] out:
[root@satellie.com] out:       foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" --certs-tar "/root/$FOREMAN_PROXY-certs.tar"
[root@satellie.com] out:
[root@satellie.com] out:   The full log is at /var/log/foreman-installer/satellite.log
[root@satellie.com] out:

[root@satellie.com] run: sed -n 8,14p /etc/named/zones.conf >> /root/zones_cons.conf
[root@satellie.com] run: cat /root/zones_cons.conf > /etc/named/zones.conf
[root@satellie.com] run: cat /root/zones-pre_osp.conf >> /etc/named/zones.conf
[root@satellie.com] run: service named restart
[root@satellie.com] out: Redirecting to /bin/systemctl restart  named.service
[root@satellie.com] out:


Done.
Disconnecting from root@satellie.com... done.
```
