### PR TITLE
Use Fabric3 (py3 Fabric fork) until original Fabric is refactored for py3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     package_dir={'automation_tools': 'automation_tools'},
     include_package_data=True,
     install_requires=[
-        'Fabric',
+        'Fabric3',
         'lxml',
         'pycurl',
         'pytest',


### PR DESCRIPTION
- helps future transition to python3