### PR TITLE
Add new task setup_avahi_discovery()

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -36,6 +36,7 @@ from automation_tools import (  # flake8: noqa
     set_yum_debug_level,
     setup_abrt,
     setup_alternate_capsule_ports,
+    setup_avahi_discovery,
     setup_ddns,
     setup_default_capsule,
     setup_default_docker,


### PR DESCRIPTION
avahi discovery is used to discover VMs deployed to a VLAN by 'ping vm.local' run at Satellite

Before we had this service run at hypervisors (but not properly setup, then setup but causing troubles to access hypervisor aside VLANs ...)

Let's have automation discovery (avahi-daemon) directly on each of Satellites. Thus it will stay isolated/related to specific virtual network and will not only work for libvirt1 VMs but for any other VMs deployed to the particular VLAN. 