### PR TITLE
Setup default subnet in postinstall time

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -41,6 +41,7 @@ from automation_tools import (  # flake8: noqa
     setup_default_capsule,
     setup_default_docker,
     setup_default_libvirt,
+    setup_default_subnet,
     setup_email_notification,
     setup_fake_manifest_certificate,
     setup_firewall,


### PR DESCRIPTION
Satellite installer currently has options only to setup default domain (we do it) but has none to setup default subnet to match Internal Capsule network setup. 

So, we need to set up some "default subnet" in postinstall time unless there are installer options for it.
