### PR TITLE
Add also short hostname into /etc/hosts

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2206,7 +2206,6 @@ def fix_hostname(entry_domain=None, host_ip=None):
     if host_ip and entry_domain:
         # Required when running product-automation.
         host = entry_domain.split('.', 1)[0]
-        run('echo "127.0.0.1 {0} localhost" > /etc/hosts'.format(entry_domain))
         run('echo "{0} {1} {2}" >> /etc/hosts'
             .format(host_ip, entry_domain, host))
     else:

--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2211,9 +2211,10 @@ def fix_hostname(entry_domain=None, host_ip=None):
             .format(host_ip, entry_domain, host))
     else:
         # Required for fixing the hostname when using satellite-installer
-        ip_addr = run("ping -c 1 $(hostname) | grep 'icmp_seq' "
-                      "| awk -F '(' '{print $2}' | awk -F ')' '{print $1}'")
-        run('echo "{0} $(hostname)" >> /etc/hosts'.format(ip_addr))
+        ip_addr = run("ping -c1 $(hostname) | awk -F\( '/icmp_seq/{print$2}' "
+                      "| awk -F\) '{print$1}'")
+        run('echo "{0} $(hostname) $(hostname -s)" >> /etc/hosts'
+            .format(ip_addr))
 
 
 def iso_download(iso_url=None):


### PR DESCRIPTION
First commit:
- short hostname is now also echoed into /etc/hosts
- awk refactor, no need for extra grep

Fixes the following error caused by missing short hostname:
```
[192.168.100.2] Executing task 'install_prerequisites'
[192.168.100.2] run: ping -c1 localhost
[192.168.100.2] out: PING localhost (127.0.0.1) 56(84) bytes of data.
[192.168.100.2] out: 64 bytes from localhost (127.0.0.1): icmp_seq=1 ttl=64 time=0.065 ms
[192.168.100.2] out: 
[192.168.100.2] out: --- localhost ping statistics ---
[192.168.100.2] out: 1 packets transmitted, 1 received, 0% packet loss, time 0ms
[192.168.100.2] out: rtt min/avg/max/mdev = 0.065/0.065/0.065/0.000 ms
[192.168.100.2] out: 

[192.168.100.2] run: ping -c1 $(hostname -s)
[192.168.100.2] out: ping: sat: Name or service not known
[192.168.100.2] out: 


Warning: run() received nonzero return code 2 while executing 'ping -c1 $(hostname -s)'!
```