### PR TITLE
Using six library for both python2 and python3 compatibility

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -22,12 +22,8 @@ from automation_tools.repository import (
 from automation_tools.utils import distro_info, update_packages
 from fabric.api import cd, env, execute, get, local, put, run, settings, sudo
 
-try:  # py3
-    from urllib.parse import urljoin
-    from urllib.parse import urlsplit
-except ImportError:  # py2
-    from urlparse import urljoin
-    from urlparse import urlsplit
+from six.moves.urllib.parse import urljoin
+from six.moves.urllib.parse import urlsplit
 
 LIBVIRT_IMAGES_DIR = '/var/lib/libvirt/images'
 

--- a/automation_tools/utils.py
+++ b/automation_tools/utils.py
@@ -8,10 +8,7 @@ import sys
 from bs4 import BeautifulSoup
 from fabric.api import env, run
 
-try:  # py3
-    from urllib.request import urlopen
-except ImportError:  # py2
-    from urllib2 import urlopen
+from six.moves.urllib.request import urlopen
 
 
 def distro_info():

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'python-bugzilla==1.2.2',
         'requests',
         'robozilla',
+        'six',
         'unittest2',
     ],
     license='GNU GPL v3.0',


### PR DESCRIPTION
This would help achieve importing the compatible libs with less code.


Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>

