### PR TITLE
No python-rhsm on RHEL7.5

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2495,7 +2495,7 @@ def update_basic_packages():
     """Updates some basic packages before we can run some real tests."""
     update_packages('subscription-manager', 'yum-utils', quiet=True)
     run('yum install -y yum-plugin-security yum-security', quiet=True)
-    run('rpm -q subscription-manager python-rhsm')
+    run('rpm -q subscription-manager')
 
 
 def client_registration_test(clean_beaker=True, update_package=True,


### PR DESCRIPTION
python-rhsm was renamed to subscription-manager-rhsm...

Anyways, the check for ```python-rhsm``` is pretty useless since ```subscription-manager``` requires it always.
So checking for subscription-manager presence is sufficient and implies python-rhsm presence.

RHEL7.5
```
# rpm -qR subscription-manager | grep rhsm
subscription-manager-rhsm = 1.20.10
```
RHEL7.4
```
# rpm -qR subscription-manager | grep rhsm
python-rhsm >= 1.19.10
```
