### PR TITLE
Fix avahi error on RHEL 7.5

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -243,6 +243,7 @@ def setup_avahi_discovery():
     if os_version >= 7:
         run('firewall-cmd --add-service mdns --permanent')
         run('firewall-cmd --reload')
+        run('service dbus restart')
     else:
         run('iptables -I INPUT -d 224.0.0.251/32 -p udp -m udp --dport 5353'
             ' -m conntrack --ctstate NEW -j ACCEPT')


### PR DESCRIPTION
This change simply restarts the dbus which seems to fix the issues
we've been seeing on RHEL 7.5.
This fix does not affect RHEL 6.

Fixes #642