### PR TITLE
Add options for preinstall/postinstall adhoc temporary fixes

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -19,7 +19,9 @@ from automation_tools.repository import (
     create_custom_repos, delete_custom_repos, disable_repos,
     disable_beaker_repos, enable_repos, enable_satellite_repos,
 )
-from automation_tools.utils import distro_info, update_packages
+from automation_tools.utils import (
+    distro_info, run_command, update_packages
+)
 from fabric.api import cd, env, execute, get, local, put, run, settings, sudo
 
 from six.moves.urllib.parse import urljoin
@@ -2245,6 +2247,7 @@ def product_install(distribution, create_vm=False, certificate_url=None,
 
     execute(setup_avahi_discovery, host=host)
 
+    execute(run_command, os.environ.get('FIX_PREINSTALL'), host=host)
     # execute returns a dictionary mapping host strings to the given task's
     # return value
     installer_options.update(execute(
@@ -2295,6 +2298,8 @@ def product_install(distribution, create_vm=False, certificate_url=None,
         sat_version=satellite_version,
         **installer_options
     )
+
+    execute(run_command, os.environ.get('FIX_POSTINSTALL'), host=host)
 
     # With SSL verification in hammer the installer should set hostname itself
     if satellite_version == 'downstream-nightly' and bz_bug_is_open('1454706'):

--- a/automation_tools/utils.py
+++ b/automation_tools/utils.py
@@ -85,6 +85,15 @@ def update_packages(*args, **kwargs):
     )
 
 
+def run_command(cmd=None):
+    """ Task to run only sane commands
+    :param str cmd: command to be run
+
+    """
+    if cmd:
+        run(cmd)
+
+
 def get_discovery_image():
     """ Task for getting unattended foreman-discovery ISO image
     :return: foreman-discovery-image iso under /var/lib/libvirt/images/

--- a/fabfile.py
+++ b/fabfile.py
@@ -85,5 +85,6 @@ from automation_tools.utils import (
     compare_builds,
     distro_info,
     get_discovery_image,
-    update_packages
+    run_command,
+    update_packages,
 )


### PR DESCRIPTION
By providing env vars ```FIX_POSTINSTALL``` and ```FIX_PREINSTALL``` as a newline separated list of commands we can easily workaround temporary issues e.g Nightly + RHEL7.5, waiting for EPEL to rebuild the package:


```
temporary_fixes.conf:
-----------------------
export FIX_PREINSTALL="
rpm -q katello-3.7.0 && rpm -q redhat-release-server-7.5 && rpm -ivh http://sesame.lab/pub/rubygem-rkerberos-0.1.3-6.el7.x86_64.rpm --nodeps
"
export FIX_POSTINSTALL=""
