### PR TITLE
Hands off of dbus

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -243,7 +243,6 @@ def setup_avahi_discovery():
     if os_version >= 7:
         run('firewall-cmd --add-service mdns --permanent')
         run('firewall-cmd --reload')
-        run('service dbus restart')
     else:
         run('iptables -I INPUT -d 224.0.0.251/32 -p udp -m udp --dport 5353'
             ' -m conntrack --ctstate NEW -j ACCEPT')


### PR DESCRIPTION
Revert "Fix avahi error on RHEL 7.5" (PR https://github.com/SatelliteQE/automation-tools/pull/678)

By restarting dbus we've run into cascading effect of what services to restart.
DBus shall not be restarted, see systemd/systemd#2925 (comment)

After dbus restart every ssh connection receives 25sec penalty. Then you need to restart systemd-logind.service to wear off this penalty, so I'm not gonna hunt what else to restart rather I'm reverting and will investigate the original issue with avahi once again.
