### PR TITLE
Default Subnet creation failover (create or update if failed)

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -493,7 +493,9 @@ def setup_default_subnet(sat_version):
         '--dhcp-id 1 --dns-id 1 --tftp-id 1 ' +
         ('--discovery-id 1' if sat_version not in ('6.1', '6.2') else '')
     ).format(**options)
-    run(command)
+    # create or update if failed
+    if run(command, warn_only=True).failed:
+        run(command.replace(' create ', ' update ', 1))
 
 
 def setup_email_notification(smtp=None):


### PR DESCRIPTION
Fixes the issue when default subnet already exists:
```
[localhost] Executing task 'setup_default_subnet'
[localhost] run: hammer -u admin -p changeme subnet create --name "Default Subnet" --network 192.168.100.0 --mask 255.255.255.0 --gateway 192.168.100.1 --dns-primary 192.168.100.1 --ipam DHCP --from 192.168.100.10 --to 192.168.100.254 --dhcp-id 1 --dns-id 1 --tftp-id 1 --discovery-id 1
[localhost] out: Could not create the subnet:
[localhost] out:   Name has already been taken
[localhost] out: 


Warning: run() received nonzero return code 65 while executing 'hammer -u admin -p changeme subnet create --name "Default Subnet" --network 192.168.100.0 --mask 255.255.255.0 --gateway 192.168.100.1 --dns-primary 192.168.100.1 --ipam DHCP --from 192.168.100.10 --to 192.168.100.254 --dhcp-id 1 --dns-id 1 --tftp-id 1 --discovery-id 1'!
```