### PR TITLE
Enable foreman-maintain repo for satellite 6.4 installation

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2300,6 +2300,18 @@ def product_install(distribution, create_vm=False, certificate_url=None,
         puppet4_repo = os.environ.get('PUPPET4_REPO')
         if puppet4_repo:
             execute(create_custom_repos, puppet4_repo=puppet4_repo, host=host)
+    # Sat6.4 and above: enable internal foreman-maintain repo for installation
+    if (
+            sat_version not in ['6.1', '6.2', '6.3']
+            and not distribution.endswith('cdn')
+    ):
+        maintain_repo = os.environ.get('MAINTAIN_REPO')
+        if maintain_repo:
+            execute(
+                create_custom_repos,
+                maintain_repo=maintain_repo,
+                host=host
+            )
     # execute returns a dictionary mapping host strings to the given task's
     # return value
     installer_options.update(execute(

--- a/automation_tools/repository.py
+++ b/automation_tools/repository.py
@@ -153,6 +153,7 @@ def enable_satellite_repos(cdn=False, beta=False, disable_enabled=True,
     ]
     if sat_version == '6.4':
         repos.append('rhel-{0}-server-ansible-2-rpms')
+        repos.append('rhel-7-server-satellite-maintenance-6-rpms')
     if beta:
         repos.append('rhel-server-{0}-satellite-6-beta-rpms')
     elif cdn:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1592023
Satellite 6.4 installation requires foreman-maintain as dependency