### PR TITLE
Update kickstart templates

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1610,7 +1610,6 @@ def setup_capsule(satellite_fqdn=None, capsule_fqdn=None, capsule_org=None,
     # Clean up
     unsubscribe()
 
-
     # Clean up and install with basic packages.
     clean_rhsm()
 

--- a/misc/base_image_creation/create-base-image.sh
+++ b/misc/base_image_creation/create-base-image.sh
@@ -24,6 +24,8 @@ echo "Enter the password for the base image."
 read pass
 echo "Enter the Authorized keys url for the base image. (Hosted authorized_keys file with jenkins key)"
 read auth_url
+echo "Do you want to disable IPv6 in base image? (Y/n)"
+read disable_ipv6
 
 if [ $os_version -eq 6 ] ; then 
     cp ks_rhel6_template /root/base-image.ks
@@ -36,6 +38,10 @@ fi
 
 if [[ $base_image == *"beta"* ]] ; then
     sed -i "s/enabled=0/enabled=1/g" /root/base-image.ks
+fi
+
+if [[ $disable_ipv6 =~ ^(n|N|no|No)$ ]] ; then
+    sed -i "/disable_ipv6/d" /root/base-image.ks
 fi
 
 # | is used as $os_url also could contain '/'.
@@ -59,6 +65,8 @@ virt-install --connect=qemu:///system \
     --hvm \
     --location=$os_url \
     --cpu host \
+    --graphics vnc,listen=0.0.0.0 \
+    --clock offset=localtime \
     --force
 
 # The argument `--cpu host` enables nested virtualization and is required to setup sat6 vms with provisioning support.

--- a/misc/base_image_creation/ks_rhel6_template
+++ b/misc/base_image_creation/ks_rhel6_template
@@ -37,7 +37,12 @@ avahi-tools
 avahi
 %end
 
-%post --logfile /dev/console
+%post --logfile /var/log/baseimage-postinstall.log
+
+ssh-keygen -t rsa -N "" -f /root/.ssh/id_dsa
+curl -sS -o /root/.ssh/authorized_keys AUTH_KEYS_URL
+restorecon -rv /root/.ssh/authorized_keys
+sysctl -w net.ipv6.conf.all.disable_ipv6=1 >> /etc/sysctl.conf
 
 cat <<EOL > /etc/yum.repos.d/rhel6.repo
 [rhel6]
@@ -47,15 +52,17 @@ enabled=0
 gpgcheck=0
 EOL
 
-echo "[ ! -f /var/log/configure_rhel6-base_image.log ] && touch /var/log/configure_rhel6-base_image.log" >> /etc/rc.local
-echo "[ -f /root/setup_configured ] && echo exiting && exit >> /var/log/configure_rhel6-base_image.log 2>&1" >> /etc/rc.local 
-echo "/etc/init.d/ntpd stop >> /var/log/configure_rhel6-base_image.log 2>&1" >> /etc/rc.local
-echo "ntpdate clock.redhat.com >> /var/log/configure_rhel6-base_image.log 2>&1" >> /etc/rc.local
-echo "iptables -F ; service iptables save ; chkconfig iptables off >> /var/log/configure_rhel6-base_image.log 2>&1" >> /etc/rc.local
-echo "service avahi-daemon start ; chkconfig avahi-daemon on  >> /var/log/configure_rhel6-base_image.log 2>&1" >> /etc/rc.local
-echo "ssh-keygen -t rsa -N \"\" -f /root/.ssh/id_dsa >> /var/log/configure_rhel6-base_image.log 2>&1" >> /etc/rc.local
-echo "wget -O ~/.ssh/authorized_keys AUTH_KEYS_URL >> /var/log/configure_rhel6-base_image.log 2>&1" >> /etc/rc.local
-echo "touch /root/setup_configured >> /var/log/configure_rhel6-base_image.log 2>&1" >> /etc/rc.local
+chmod +x /etc/rc.local 
+cat << EOF >> /etc/rc.local
+(
+    [ -f /root/setup_configured ] && echo exiting && exit
+    iptables -I INPUT -d 224.0.0.251/32 -p udp -m udp --dport 5353 -m conntrack --ctstate NEW -j ACCEPT
+    service iptables save
+    ntpdate clock.redhat.com
+    rm -f /etc/udev/rules.d/70-persistent-net.rules
+    touch /root/setup_configured
+) 2>&1 | tee -a /var/log/baseimage-firstboot.log
+EOF
 
 %end
 

--- a/misc/base_image_creation/ks_rhel7_template
+++ b/misc/base_image_creation/ks_rhel7_template
@@ -38,7 +38,11 @@ yum-utils
 avahi
 %end
 
-%post --logfile /dev/console
+%post --logfile /var/log/baseimage-postinstall.log
+
+ssh-keygen -t rsa -N "" -f /root/.ssh/id_dsa
+curl -sS -o /root/.ssh/authorized_keys AUTH_KEYS_URL
+sysctl -w net.ipv6.conf.all.disable_ipv6=1 >> /etc/sysctl.conf
 
 cat <<EOL > /etc/yum.repos.d/rhel7.repo
 [rhel7]
@@ -48,15 +52,15 @@ enabled=0
 gpgcheck=0
 EOL
 
-chmod +x /etc/rc.d/rc.local 
-echo "[ ! -f /var/log/configure_rhel7-base_image.log ] && touch /var/log/configure_rhel7-base_image.log" >> /etc/rc.local
-echo "[ -f /root/setup_configured ] && echo exiting && exit >> /var/log/configure_rhel7-base_image.log 2>&1" >> /etc/rc.local
-echo "iptables -F >> /var/log/configure_rhel7-base_image.log 2>&1" >> /etc/rc.local
-echo "service avahi-daemon start ; chkconfig avahi-daemon on  >> /var/log/configure_rhel7-base_image.log 2>&1" >> /etc/rc.local
-echo "ssh-keygen -t rsa -N \"\" -f /root/.ssh/id_dsa >> /var/log/configure_rhel7-base_image.log 2>&1" >> /etc/rc.local
-# Sleep is currently being used as RHEL7 uses systemd, which enables services in parallel. wget should not get run before network is enabled.
-echo "sleep 10 ; wget -O ~/.ssh/authorized_keys  AUTH_KEYS_URL >> /var/log/configure_rhel7-base_image.log 2>&1" >> /etc/rc.local
-echo "touch /root/setup_configured >> /var/log/configure_rhel7-base_image.log 2>&1" >> /etc/rc.local
+chmod +x /etc/rc.local 
+cat << EOF >> /etc/rc.local
+(
+    [ -f /root/setup_configured ] && echo exiting && exit
+    firewall-cmd --add-service mdns --permanent
+    ntpdate clock.redhat.com
+    touch /root/setup_configured
+) 2>&1 | tee -a /var/log/baseimage-firstboot.log
+EOF
 
 %end
 


### PR DESCRIPTION
- fixes VM timezone settings when OS sets `America/New_York` while HW clock is set to `UTC`
- fixes unreliable mDNS discovery when record disappears after 2mins
- do as much as possible in postinstall time since network is set up (ssh keygen, authorized keys)
- fixes authorized keys put in rhel6 postinstall has wrong selinux fcontext
- rc.local logs both on console and in the log
- handle IPv6 disablement

