### PR TITLE
Added support to configure telemetery

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -3245,3 +3245,33 @@ def setup_rhv_ca():
         '/etc/pki/ca-trust/source/anchors/'.format(http_server))
     run('update-ca-trust enable ; update-ca-trust')
     print("RHV CA cert has been successfully added to CA trust")
+
+
+def configure_telemetry():
+    """Setup telemetry on the satellite box with grafana monitoring tool
+    """
+    http_server = os.environ.get('HTTP_SERVER_HOSTNAME')
+    print("Install required packages for PCP")
+    run('yum -y install pcp pcp-pmda-apache')
+    run('wget {0}/pub/configure_telemetry.sh'.format(http_server))
+    print("Configure Apache and hotproc")
+    run('chmod 777 configure_telemetry.sh && ./configure_telemetry.sh')
+    run('cd /var/lib/pcp/pmdas/proc/ && ./Install <<< c')
+    run('cd /var/lib/pcp/pmdas/apache && ./Install <<< 80')
+    run('echo "apache::purge_configs: false" '
+        '>>/etc/foreman-installer/custom-hiera.yaml')
+    run('systemctl restart httpd pmcd pmlogger')
+    run('yum -y install foreman-telemetry pcp-mmvstatsd')
+    print("Enable telemetry via Statsd protocol")
+    run('satellite-installer --foreman-telemetry-statsd-enabled true')
+    run('systemctl restart httpd')
+    run('systemctl enable pcp-mmvstatsd pmcd pmlogger && '
+        'systemctl start pcp-mmvstatsd')
+    print("The telemetry metrics matrix")
+    run('foreman-rake telemetry:metrics')
+    print('Grafana Tool setup')
+    run('subscription-manager repos --enable rhel-7-server-optional-rpms')
+    run('yum -y install pcp-webapi pcp-webapp-grafana pcp-webapp-vector')
+    run('systemctl start pmwebd && systemctl enable pmwebd')
+    run('firewall-cmd --add-port=44323/tcp && '
+        'firewall-cmd --permanent --add-port=44323/tcp')

--- a/fabfile.py
+++ b/fabfile.py
@@ -10,6 +10,7 @@ from automation_tools import (  # noqa: F401
     configure_idm_external_auth,
     configure_realm,
     configure_sonarqube,
+    configure_telemetry,
     create_personal_git_repo,
     download_manifest,
     downstream_install,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from os import system, environ
 try:
     from setuptools import setup
 except ImportError:
@@ -7,6 +8,13 @@ except ImportError:
 
 with open('README.rst', 'r') as f:
     readme = f.read()
+
+if system('curl --version | grep NSS 2>/dev/null') != 0:
+    environ['PYCURL_SSL_LIBRARY'] = 'openssl'
+    system('pip install --compile --install-option="--with-openssl" pycurl')
+else:
+    environ['PYCURL_SSL_LIBRARY'] = 'nss'
+    system('pip install --compile --install-option="--with-nss" pycurl')
 
 setup(
     name='automation_tools',


### PR DESCRIPTION
```
root  ~  HTTP_SERVER_HOSTNAME=http-host fab configure_telemetry
Install required packages for PCP
No hosts found. Please specify (single) host string for connection: root@sat-host
[root@sat-host] run: yum -y install pcp pcp-pmda-apache
[root@sat-host] Login password for 'root': 
[root@sat-host] out: Package pcp-3.12.2-5.el7.x86_64 already installed and latest version
[root@sat-host] out: Package pcp-pmda-apache-3.12.2-5.el7.x86_64 already installed and latest version
[root@sat-host] out: 

[root@sat-host] run: wget http-host/pub/configure_telemetry.sh
[root@sat-host] out: --2018-08-14 09:14:50--  http://http-host/pub/configure_telemetry.sh
[root@sat-host] out: Resolving http-host (http-host)... 0.0.0.99
[root@sat-host] out: Connecting to http-host (http-host)|0.0.0.99|:80... connected.
[root@sat-host] out: HTTP request sent, awaiting response... 200 OK
[root@sat-host] out: Length: 1616 (1.6K) [application/x-sh]
[root@sat-host] out: Saving to: ‘configure_telemetry.sh’
[root@sat-host] out: 
[root@sat-host] out: 
[root@sat-host] out:  0% [                                                                                                                                                                          ] 0           --.-K/s              
[root@sat-host] out: 100%[=========================================================================================================================================================================>] 1,616       --.-K/s   in 0s      
[root@sat-host] out: 
[root@sat-host] out: 2018-08-14 09:14:50 (152 MB/s) - ‘configure_telemetry.sh’ saved [1616/1616]
[root@sat-host] out: 
[root@sat-host] out: 

Configure Apache and hotproc
[root@sat-host] run: chmod 777 configure_telemetry.sh && ./configure_telemetry.sh
[root@sat-host] run: cd /var/lib/pcp/pmdas/proc/ &&  c | ./Install
[root@sat-host] out: /bin/bash: c: command not found
[root@sat-host] out: You will need to choose an appropriate configuration for installation of
[root@sat-host] out: the "proc" Performance Metrics Domain Agent (PMDA).
[root@sat-host] out: 
[root@sat-host] out:   collector	collect performance statistics on this system
[root@sat-host] out:   monitor	allow this system to monitor local and/or remote systems
[root@sat-host] out:   both		collector and monitor configuration for this system
[root@sat-host] out: 
[root@sat-host] out: Please enter c(ollector) or m(onitor) or b(oth) [b] Updating the Performance Metrics Name Space (PMNS) ...
[root@sat-host] out: Terminate PMDA if already installed ...
[root@sat-host] out: Updating the PMCD control file, and notifying PMCD ...
[root@sat-host] out: Check proc metrics have appeared ... 5 warnings, 123 metrics and 23123 values
[root@sat-host] out: 

[root@sat-host] run: cd /var/lib/pcp/pmdas/apache && 80 | ./Install
[root@sat-host] out: /bin/bash: 80: command not found
[root@sat-host] out: Installing the "apache" Performance Metrics Domain Agent (PMDA) ...
[root@sat-host] out: 
[root@sat-host] out: Apache port number [80]? Updating the Performance Metrics Name Space (PMNS) ...
[root@sat-host] out: Terminate PMDA if already installed ...
[root@sat-host] out: Updating the PMCD control file, and notifying PMCD ...
[root@sat-host] out: Check apache metrics have appeared ... 20 metrics and 0 values
[root@sat-host] out: 

[root@sat-host] run: echo "apache::purge_configs: false" >>/etc/foreman-installer/custom-hiera.yaml
[root@sat-host] run: systemctl restart httpd pmcd pmlogger
[root@sat-host] run: yum -y install foreman-telemetry pcp-mmvstatsd
[root@sat-host] out: 
[root@sat-host] out: ===================================================================================================================================================================================================================
[root@sat-host] out:  Package                                               Arch                           Version                                     Repository                                                                  Size
[root@sat-host] out: ===================================================================================================================================================================================================================
[root@sat-host] out: Installing:
[root@sat-host] out:  foreman-telemetry                                     noarch                         1.18.0.5-1.el7sat                           Sat6-CI_Satellite_6_4_Composes_Satellite_6_4_RHEL7                          12 k
[root@sat-host] out:  pcp-mmvstatsd                                         x86_64                         0.4-1.el7sat                                Sat6-CI_Satellite_6_4_Composes_Satellite_6_4_RHEL7                         839 k
[root@sat-host] out: Installing for dependencies:
[root@sat-host] out:  tfm-rubygem-prometheus-client                         noarch                         0.7.1-1.el7sat                              Sat6-CI_Satellite_6_4_Composes_Satellite_6_4_RHEL7                          13 k
[root@sat-host] out:  tfm-rubygem-quantile                                  noarch                         0.2.0-1.el7sat                              Sat6-CI_Satellite_6_4_Composes_Satellite_6_4_RHEL7                          11 k
[root@sat-host] out:  tfm-rubygem-statsd-instrument                         noarch                         2.1.4-1.el7sat                              Sat6-CI_Satellite_6_4_Composes_Satellite_6_4_RHEL7                          17 k
[root@sat-host] out: 
[root@sat-host] out: Transaction Summary
[root@sat-host] out: ===================================================================================================================================================================================================================
[root@sat-host] out: Install  2 Packages (+3 Dependent packages)
[root@sat-host] out: 
[root@sat-host] out: Total download size: 892 k
[root@sat-host] out: Installed size: 2.8 M
[root@sat-host] out: 
[root@sat-host] out: Installed:
[root@sat-host] out:   foreman-telemetry.noarch 0:1.18.0.5-1.el7sat                                                                 pcp-mmvstatsd.x86_64 0:0.4-1.el7sat                                                                
[root@sat-host] out: 
[root@sat-host] out: Dependency Installed:
[root@sat-host] out:   tfm-rubygem-prometheus-client.noarch 0:0.7.1-1.el7sat                    tfm-rubygem-quantile.noarch 0:0.2.0-1.el7sat                    tfm-rubygem-statsd-instrument.noarch 0:2.1.4-1.el7sat                   
[root@sat-host] out: 
[root@sat-host] out: 

Enable telemetry via Statsd protocol
[root@sat-host] run: satellite-installer --foreman-telemetry-statsd-enabled true
[root@sat-host] out: Resetting puppet server version param...
Installing             Done                                               [100%] [................................................................................................................................]
[root@sat-host] out:   Success!
[root@sat-host] out:   * Satellite is running at https://sat-host
[root@sat-host] out: 
[root@sat-host] out:   * To install an additional Capsule on separate machine continue by running:
[root@sat-host] out: 
[root@sat-host] out:       capsule-certs-generate --foreman-proxy-fqdn "$CAPSULE" --certs-tar "/root/$CAPSULE-certs.tar"
[root@sat-host] out: 
[root@sat-host] out:   * To upgrade an existing 6.3 Capsule to 6.4:
[root@sat-host] out:       Please see official documentation for steps and parameters to use when upgrading a 6.3 Capsule to 6.4.
[root@sat-host] out: 
[root@sat-host] out:   The full log is at /var/log/foreman-installer/satellite.log
[root@sat-host] out: 

[root@sat-host] run: systemctl restart httpd
[root@sat-host] run: systemctl enable pcp-mmvstatsd pmcd pmlogger && systemctl start pcp-mmvstatsd
[root@sat-host] out: Created symlink from /etc/systemd/system/multi-user.target.wants/pcp-mmvstatsd.service to /usr/lib/systemd/system/pcp-mmvstatsd.service.
[root@sat-host] out: Created symlink from /etc/systemd/system/multi-user.target.wants/pmcd.service to /usr/lib/systemd/system/pmcd.service.
[root@sat-host] out: Created symlink from /etc/systemd/system/multi-user.target.wants/pmlogger.service to /usr/lib/systemd/system/pmlogger.service.
[root@sat-host] out: 

The telemetry metrics matrix
[root@sat-host] run: foreman-rake telemetry:metrics
[root@sat-host] out: /usr/share/foreman/lib/foreman.rb:8: warning: already initialized constant Foreman::UUID_REGEXP
[root@sat-host] out: /usr/share/foreman/lib/foreman.rb:8: warning: previous definition of UUID_REGEXP was here
[root@sat-host] out: /usr/share/foreman/lib/core_extensions.rb:182: warning: already initialized constant ActiveSupport::MessageEncryptor::DEFAULT_CIPHER
[root@sat-host] out: /opt/theforeman/tfm-ror51/root/usr/share/gems/gems/activesupport-5.1.6/lib/active_support/message_encryptor.rb:22: warning: previous definition of DEFAULT_CIPHER was here
[root@sat-host] out: | Metric name | Labels | Type | Description |
[root@sat-host] out: | ----------- | ------ | ---- | ----------- |
[root@sat-host] out: | fm_rails_activerecord_instances | class | counter | Number of instances of ActiveRecord models |
[root@sat-host] out: | fm_rails_bruteforce_locked_ui_logins |  | counter | Number of blocked logins via bruteforce protection |
[root@sat-host] out: | fm_rails_failed_ui_logins |  | counter | Number of failed logins in total |
[root@sat-host] out: | fm_rails_http_request_db_duration | controller,action | histogram | Time spent in database for a request |
[root@sat-host] out: | fm_rails_http_request_total_duration | controller,action | histogram | Total duration of controller action |
[root@sat-host] out: | fm_rails_http_request_view_duration | controller,action | histogram | Time spent in view for a request |
[root@sat-host] out: | fm_rails_http_requests | controller,action | counter | A counter of HTTP requests made |
[root@sat-host] out: | fm_rails_importer_facts_count_input | type | counter | Number of facts before imports starts per importer type |
[root@sat-host] out: | fm_rails_importer_facts_count_interfaces | type | counter | Number of changed interfaces per importer type |
[root@sat-host] out: | fm_rails_importer_facts_count_processed | type,action | counter | Number of facts processed (added, updated, deleted) per importer type |
[root@sat-host] out: | fm_rails_importer_facts_import_duration | type | histogram | Duration of fact import (ms) per importer type |
[root@sat-host] out: | fm_rails_importer_facts_populate_duration | type | histogram | Duration of fields population (ms) per importer type |
[root@sat-host] out: | fm_rails_ldap_request_duration |  | histogram | Total duration of LDAP requests |
[root@sat-host] out: | fm_rails_proxy_api_duration | method | histogram | Time spent waiting for Proxy (ms) |
[root@sat-host] out: | fm_rails_proxy_api_response_code | code | counter | Number of Proxy API responses per HTTP code |
[root@sat-host] out: | fm_rails_ruby_gc_allocated_objects | controller,action | counter | Ruby GC statistics per request (total_allocated_objects) |
[root@sat-host] out: | fm_rails_ruby_gc_count | controller,action | counter | Ruby GC statistics per request (count) |
[root@sat-host] out: | fm_rails_ruby_gc_freed_objects | controller,action | counter | Ruby GC statistics per request (total_freed_objects) |
[root@sat-host] out: | fm_rails_ruby_gc_major_count | controller,action | counter | Ruby GC statistics per request (major_gc_count) |
[root@sat-host] out: | fm_rails_ruby_gc_minor_count | controller,action | counter | Ruby GC statistics per request (minor_gc_count) |
[root@sat-host] out: | fm_rails_successful_ui_logins |  | counter | Number of successful logins in total |
[root@sat-host] out: 


Done.

```