### PR TITLE
Activate permanent fw rules

### DIFF
--- a/misc/base_image_creation/ks_rhel7_template
+++ b/misc/base_image_creation/ks_rhel7_template
@@ -58,6 +58,7 @@ cat << EOF >> /etc/rc.local
 (
     [ -f /root/setup_configured ] && echo exiting && exit
     firewall-cmd --add-service mdns --permanent
+    firewall-cmd --reload
     ntpdate clock.redhat.com
     touch /root/setup_configured
 ) 2>&1 | tee -a /var/log/baseimage-firstboot.log


### PR DESCRIPTION
Just one simple `firewall-cmd --reload` added for rhel7 ks 