### PR TITLE
Unpin Pynacl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         'robozilla',
         'six',
         'unittest2',
-        'PyNaCl==1.2.1'
     ],
     license='GNU GPL v3.0',
     classifiers=(


### PR DESCRIPTION
There is no need to pin ```PyNaCl==1.2.1``` 
PyNaCl 1.3.0 caused an error:
```
Building wheels for collected packages: pynacl
  Running setup.py bdist_wheel for pynacl: started
  Running setup.py bdist_wheel for pynacl: finished with status 'error'
  Complete output from command /home/jenkins/shiningpanda/jobs/c5ba8d5c/virtualenvs/d41d8cd9/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-lj3o7ncd/pynacl/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-ticu7w36 --python-tag cp36:
  running bdist_wheel
...

  configure: creating ./config.status
  config.status: error: cannot find input file: `/home/jenkins/workspace/provisioning-6.4-rhel7@tmp/config9102616952060624847tmp.in'
```

However I'm not able to reproduce error both on my local machine (py27, py36, py37) and ```rosemary```, ```paprika``` (py36). 
```
Successfully installed automation-tools pynacl-1.3.0
```


The error had to be sort of intermittent one. Thus reverting the PR.


Reverts SatelliteQE/automation-tools#730