### PR TITLE
Escape $ signs in encrypted password

### DIFF
--- a/automation_tools/baseimage.py
+++ b/automation_tools/baseimage.py
@@ -57,7 +57,7 @@ def create_baseimage(os_url, image=None, auth_keys_url=None, dns_server=None, di
 
     put('misc/base_image_creation/ks_rhel{}_template'.format(os_ver), 'ks.cfg')
     run('sed -i "s|OS_URL|{}|g" ks.cfg'.format(os_url))
-    run('sed -i "s|ENCRYPT_PASS|$1$xyz$7xHVh4/yhE6P00NIXbWZA/|g" ks.cfg')
+    run('sed -i "s|ENCRYPT_PASS|\\$1\\$xyz\\$7xHVh4/yhE6P00NIXbWZA/|g" ks.cfg')
     run('sed -i "s|AUTH_KEYS_URL|{}|g" ks.cfg'.format(auth_keys_url))
     if not disable_ipv6:
         run('sed -i "/disable_ipv6/d" ks.cfg')


### PR DESCRIPTION
Fixes inability to log in into baseimage using password

@rplevka thx for reporting the issue