### PR TITLE
Fixes setup_ddns task

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -166,6 +166,7 @@ def setup_ddns(entry_domain, host_ip):
 
     * `DDNS_HASH`
     * `DDNS_PACKAGE_URL`
+    * `INTERNAL_CERT_URL`
 
     :param str entry_domain: the FQDN of the host
     :param str entry_hash: host FQDN DDNS entry hash
@@ -182,11 +183,20 @@ def setup_ddns(entry_domain, host_ip):
         print('The DDNS_PACKAGE_URL environment variable should be defined')
         sys.exit(1)
 
+    os_version = distro_info()[1]
+
     target, domain = entry_domain.split('.', 1)
+
+    if os_version >= 7:
+        internal_cert_url = os.environ.get('internal_cert_url')
+        if internal_cert_url is None:
+            print('The internal_cert_url environment variable should be defined')
+            sys.exit(1)
+
+        run('yum localinstall -y {0}'.format(internal_cert_url))
 
     run('yum localinstall -y {0}'.format(ddns_package_url))
 
-    os_version = distro_info()[1]
     if os_version >= 7:
         run('echo "{0} {1} {2}" >> /etc/redhat-internal-ddns/hosts'.format(
             target, domain, ddns_hash))


### PR DESCRIPTION
DDNS_PACKAGE_URL for rhel 7 was outdated, updated it in gitlab and new package has dependency of internal_cert_install package.

Depends on gitlab PR 199 