### PR TITLE
disable_base_os checks also os_upgrade_repos

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1134,7 +1134,7 @@ def disable_baseos_repo():
     IMAGE
         The custom image name to be used for vault_requests.
     """
-    if os.environ.get('IMAGE'):
+    if os.environ.get('OS_UPGRADE_REPOS'):
         os_version = distro_info()[1]
         disable_repos('rhel-{0}-server-rpms'.format(os_version))
 


### PR DESCRIPTION
fixes #747, helps running at with custom fips image that requires base-os for yum update afterwards. 