### PR TITLE
add setup_bfa_prevention to set the failed login attempts limit

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -39,6 +39,7 @@ from automation_tools import (  # noqa: F401
     setup_abrt,
     setup_alternate_capsule_ports,
     setup_avahi_discovery,
+    setup_bfa_prevention,
     setup_capsule,
     setup_ddns,
     setup_default_capsule,


### PR DESCRIPTION
since 6.5, there's a global setting allowing us to control the Brute-force-attack prevention mechanism by specifying the failed-attempt count limit.
This task allows us to control it from `product_install` task.