### PR TITLE
Restarting foreman services in setup_discovery not needed

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1077,8 +1077,6 @@ def setup_foreman_discovery(sat_version):
         run('rpm -q {0}'.format(' '.join(packages)))
         run('yum install -y foreman-discovery-image')
 
-    for daemon in ('foreman', 'httpd', 'foreman-proxy'):
-        manage_daemon('restart', daemon)
     # Unlock the default Locked template for discovery
     run('hammer -u admin -p {0} template update '
         '--name "PXELinux global default" --locked "false"'


### PR DESCRIPTION
Restarting services not needed in setup_discovery task.
Now in upstream nightly, foreman service is not available (t is part of foreman-service rpm which is not mandatory.). so job is failing. 
Refs : foreman-packaging/pull/3315