### PR TITLE
Satellite 6.4, 6.5 is supposed to use rhel-7-server-ansible-2.6-rpms repo

### DIFF
--- a/automation_tools/repository.py
+++ b/automation_tools/repository.py
@@ -159,7 +159,11 @@ def enable_satellite_repos(cdn=False, beta=False, disable_enabled=True,
             'rhel-{0}-server-rpms',
             'rhel-server-rhscl-{0}-rpms',
         ]
-        if sat_version != '6.3':  # 6.4+
+        if sat_version in ['6.4', '6.5']:
+            repos.append('rhel-{0}-server-ansible-2.6-rpms')
+            repos.append('rhel-{0}-server-satellite-maintenance-6-rpms')
+        if sat_version == '6.6':
+            # Ansible '2.8' was not released yet, so using '2' repo
             repos.append('rhel-{0}-server-ansible-2-rpms')
             repos.append('rhel-{0}-server-satellite-maintenance-6-rpms')
     if beta:


### PR DESCRIPTION
See https://access.redhat.com/documentation/en-us/red_hat_satellite/6.4/html-single/installing_satellite_server_from_a_connected_network/index#configuring_repositories_satellite