### PR TITLE
Fix rhel8 yum-config-manager for nonexistent (beaker) repo has rc=1

### DIFF
--- a/automation_tools/repository.py
+++ b/automation_tools/repository.py
@@ -181,10 +181,9 @@ def disable_beaker_repos(**kwargs):
     # Clean up system if Beaker-based
     result = run('which yum-config-manager', quiet=True)
     if result.succeeded:
-        run('yum-config-manager --disable "beaker*"')
+        run('yum-config-manager --disable "beaker*"', warn_only=True)
     else:
-        run('sed -i "s/^enabled=.*/enabled=0/" /etc/yum.repos.d/beaker-*.repo',
-            warn_only=True)
+        run('sed -i "s/^enabled=.*/enabled=0/" /etc/yum.repos.d/beaker-*.repo', warn_only=True)
     run('rm -rf /var/cache/yum*')
 
 


### PR DESCRIPTION
...while on rhel7 has rc=0

I remember me filing such BZ against RHEL7.1 so this BZ seem to be fixed finally in RHEL8 :-D