### PR TITLE
Integrate fix_hostname task even for standalone installer job

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2307,6 +2307,9 @@ def product_install(distribution, create_vm=False, certificate_url=None,
 
         execute(vm_destroy, target_image, delete_image=True)
         execute(vm_create)
+    else:
+        # if host already exists (vm_create=False) still fix hostname
+        execute(fix_hostname)
 
     # When creating a vm the vm_ip will be set, otherwise use the fabric host
     host = env.get('vm_ip', env['host'])


### PR DESCRIPTION
Integrate ```fix_hostname``` task in ```product_install``` task so that standalone installer job and doesn't need extra fab command and is more unified with provisioning job