### PR TITLE
Fix systemctl status may hang when redirected to pager (less)

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -611,7 +611,7 @@ def setup_firewall(definitions=None, flush=True):
     else:
         if run('rpm -q firewalld', quiet=True).failed:
             run('yum install -y firewalld')
-        if run('systemctl status firewalld', quiet=True).failed:
+        if run('systemctl --no-pager status firewalld', quiet=True).failed:
             run('systemctl enable firewalld')
             run('systemctl start firewalld')
         exists_command = 'firewall-cmd --permanent --query-port="{1}/{0}"'


### PR DESCRIPTION
Fixes possibly (on rhel8 regularly) hanging "systemctl status ...":
```
 # systemctl status firewalld
● firewalld.service - firewalld - dynamic firewall daemon
   Loaded: loaded (/usr/lib/systemd/system/firewalld.service; enabled; vendor p>
   Active: active (running) since Sun 2019-05-19 18:39:20 EDT; 1 day 3h ago
     Docs: man:firewalld(1)
 Main PID: 882 (firewalld)
    Tasks: 3 (limit: 26213)
   Memory: 37.2M
   CGroup: /system.slice/firewalld.service
           └─882 /usr/libexec/platform-python -s /usr/sbin/firewalld --nofork ->

May 19 18:39:20 <very very long fully qualified domain name> systemd[1]: Starti>
May 19 18:39:20 <very very long fully qualified domain name> systemd[1]: Starte>
May 20 21:18:40 <very very long fully qualified domain name> firewalld[882]: WA>
lines 1-13/13 (END)
```
Hehe automation run was hanging 3 days in pager (less)
