### PR TITLE
Remove enable_ostree() task and add installer option instead

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -14,7 +14,6 @@ from automation_tools import (  # noqa: F401
     create_personal_git_repo,
     download_manifest,
     downstream_install,
-    enable_ostree,
     enroll_ad,
     enroll_idm,
     errata_upgrade,


### PR DESCRIPTION
This fixes upstream where running installer with ```--katello-enable-ostree=true``` additionally causes pulp misbehavior while running this option at once causes no issues to pulp.

So it will speed up any SAT installation saving one (redundant) installer run