### PR TITLE
Fix capsule-cert-generate command

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1499,7 +1499,7 @@ def generate_capsule_certs(capsule_fqdn=None, sat_version=None):
         .format(capsule_fqdn))
     run('cat /var/www/html/pub/{0}-out.txt|'
         'grep -v help | grep -v log | grep -A 10 "satellite-installer'
-        ' --scenario capsule" > /var/www/html/pub/capsule_script.sh'
+        '" > /var/www/html/pub/capsule_script.sh'
         .format(capsule_fqdn))
     run('chmod +x /var/www/html/pub/capsule_script.sh')
     run('sed -i \'s|/var/www/html/pub/{0}-certs.tar|/root/{0}-certs.tar|\' '


### PR DESCRIPTION
Fixed job/capsule-sanity-check-6.6-rhel7/6/console

Regex changed due to https://bugzilla.redhat.com/show_bug.cgi?id=1709761