### PR TITLE
Fix versionlock prevents satellite rpms to install (BZ #1738199)

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1019,11 +1019,6 @@ def setup_foreman_discovery(sat_version):
 
     :param str sat_version: contains Satellite version e.g. 6.3
     """
-    packages = (
-        'tfm-rubygem-foreman_discovery',
-        'rubygem-smart_proxy_discovery',
-        'tfm-rubygem-hammer_cli_foreman_discovery',
-    )
     admin_password = os.environ.get('ADMIN_PASSWORD', 'changeme')
 
     if sat_version == 'upstream-nightly':
@@ -1032,8 +1027,13 @@ def setup_foreman_discovery(sat_version):
         run('wget -nv -O- {0} | tar x --overwrite -C /var/lib/tftpboot/boot'.format(image_url))
     else:
         # Since 6.3, installer should install all required packages except FDI
-        run('rpm -q {0}'.format(' '.join(packages)))
+        if float(sat_version) > 6.5:
+            # Check BZ 1738199 for final solution (versionlock prevents satellite rpms to install)
+            run('foreman-maintain packages unlock')
         run('yum install -y foreman-discovery-image')
+        if float(sat_version) > 6.5:
+            # Check BZ 1738199 for final solution (versionlock prevents satellite rpms to install)
+            run('foreman-maintain packages lock')
 
     # Unlock the default Locked template for discovery
     run('hammer -u admin -p {0} template update '


### PR DESCRIPTION
Instead of running ```satellite-installer --no-lock-package-versions``` (permanent change) I chose to run much faster ```foreman-maintain packages unlock``` (effective till next installer run)

This command is also supposed to be run by customers when performing some exceptional package install. Satellite package such as ```foreman-discovery-image``` shouldn't be some exceptional.

That's what https://bugzilla.redhat.com/show_bug.cgi?id=1738199 is about. The issue is that the new locking mechanism assumes that all packages are either installed by default or handled by installer. That is not true, the most important example is foreman-discovery-image
