### PR TITLE
Ensure fuser is present

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -3236,9 +3236,10 @@ def setup_alternate_capsule_ports(port_range='9400-14999'):
     # nmap's ncat (opposite to nc) supports -c option we use for capsule faking
     # and rhel7 has separate package for ncat named nmap-ncat
     run('which nmap || yum -d1 -y install nmap', warn_only=True)
+    # fuser is used to find out available ports to listen on
+    run('which fuser || yum -d1 -y install psmisc', warn_only=True)
     # labelling custom port range so that passenger will be allowed to connect
-    run('semanage port -a -t websm_port_t -p tcp {0}'
-        .format(port_range), warn_only=True)
+    run('semanage port -a -t websm_port_t -p tcp {0}'.format(port_range), warn_only=True)
 
 
 def setup_rhv_ca():


### PR DESCRIPTION
On upstream ```fuser``` cmd is missing while on downstream is pulled in by ```foreman-discovery-image``` rpm thus no action was ever needed.

Fixes the following error in nightly automation:
```
2019-08-11 18:57:54 - robottelo - INFO - Started setUpClass: tests.foreman.api.test_smartproxy/CapsuleTestCase
2019-08-11 18:57:54 - robottelo - DEBUG - Started Test: CapsuleTestCase/test_positive_refresh_features
2019-08-11 18:57:54 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f66b4cdf0b8
2019-08-11 18:57:54 - robottelo.ssh - INFO - Connected to [qe-foreman-rhel7-tier2.example.com]
2019-08-11 18:57:54 - robottelo.ssh - INFO - >>> fuser -n tcp {9400..14998} 2>&1 | awk -F/ '{print$1}'
2019-08-11 18:57:55 - robottelo.ssh - INFO - <<< stdout
bash: fuser: command not found
```