### PR TITLE
Satellite Maintain repo related changes

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2236,11 +2236,7 @@ def product_install(distribution, create_vm=False, certificate_url=None,
         puppet4_repo = os.environ.get('PUPPET4_REPO')
         if puppet4_repo:
             execute(create_custom_repos, puppet4_repo=puppet4_repo, host=host)
-    # Sat6.4 and above: enable internal foreman-maintain repo for installation
-    if sat_version != '6.3' and not distribution.endswith('cdn'):
-        maintain_repo = os.environ.get('MAINTAIN_REPO')
-        if maintain_repo:
-            execute(create_custom_repos, maintain_repo=maintain_repo, host=host)
+
     # execute returns a dictionary mapping host strings to the given task's
     # return value
     installer_options.update(execute(

--- a/automation_tools/repository.py
+++ b/automation_tools/repository.py
@@ -162,11 +162,10 @@ def enable_satellite_repos(cdn=False, beta=False, disable_enabled=True,
         ]
         if sat_version in ['6.4', '6.5']:
             repos.append('rhel-{0}-server-ansible-2.6-rpms')
-            repos.append('rhel-{0}-server-satellite-maintenance-6-rpms')
         if sat_version == '6.6':
             # Ansible '2.8' was not released yet, so using '2' repo
             repos.append('rhel-{0}-server-ansible-2-rpms')
-            repos.append('rhel-{0}-server-satellite-maintenance-6-rpms')
+
     if beta:
         repos.append('rhel-server-{0}-satellite-6-beta-rpms')
     elif cdn:
@@ -174,6 +173,12 @@ def enable_satellite_repos(cdn=False, beta=False, disable_enabled=True,
         # Sat6.3: enable *cdn* puppet4 repo to perform fresh p4 install
         if sat_version == '6.3' and puppet4 == 'yes':
             repos.append('rhel-{0}-server-satellite-{1}-puppet4-rpms')
+
+    if sat_version in ['6.4', '6.5', '6.6']:
+        if beta:
+            repos.append('rhel-{0}-server-satellite-maintenance-6-beta-rpms')
+        else:
+            repos.append('rhel-{0}-server-satellite-maintenance-6-rpms')
 
     enable_repos(*[repo.format(os_version, sat_version) for repo in repos])
     run('yum repolist')


### PR DESCRIPTION
Fix #796 Removed creation of satellite-maintain repo since it is provided as part of activation keys, repofiles, etc already.
Fix #797. When "BETA" is set (during CDN install), use beta satellite-maintenance