### PR TITLE
Fixes failure with upstream-nightly sat-version

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -3278,7 +3278,7 @@ def configure_telemetry(http_server=None):
 def package_install(packages, sat_version=None):
     # Fetch the Satellite Version information.
     sat_version = sat_version or os.environ.get('SATELLITE_VERSION')
-    if sat_version is not None and float(sat_version) >= 6.6:
+    if sat_version is not None and sat_version not in ('6.3', '6.4', '6.5'):
         command = 'foreman-maintain packages install -y {}'.format(packages)
     else:
         command = 'yum -y install {}'.format(packages)


### PR DESCRIPTION
Fixes failure of job If sat_version is 'upstream-nightly' 
```
  if sat_version is not None and float(sat_version) >= 6.6:
ValueError: could not convert string to float: 'upstream-nightly'
```