### PR TITLE
Fix parsing MD5SUM file in order to find out ISO name

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -12,7 +12,7 @@ import sys
 import time
 from datetime import date
 from io import StringIO
-from re import search
+from re import MULTILINE, search
 
 from automation_tools.bz import bz_bug_is_open
 from automation_tools.repository import (
@@ -2448,7 +2448,7 @@ def iso_download(iso_url=None):
             if result.succeeded:
                 # match either '<hash> *<iso_filename>'
                 # or '{MD5|SHA1|SHA256} (<iso_filename>) = <hash>'
-                iso_filename = search(r'\w+\s+[\*\(]?([^\s\)]+)', result).group(1)
+                iso_filename = search(r'^\w+\s+[\*\(]?([^\s\)]+)', result, MULTILINE).group(1)
                 break
 
         if iso_filename is None:


### PR DESCRIPTION
(ignore commented lines in MD5SUM, SHA1SUM, SHA256SUM files)

This PR fixes parsing of the folowing sum file (pls note line 1 is commented):
```
# Satellite-6.6.0-RHEL-7-20191009.n.0-Satellite-x86_64-dvd1.iso: 3121461248 bytes
MD5 (Satellite-6.6.0-RHEL-7-20191009.n.0-Satellite-x86_64-dvd1.iso) = a127cdba213a2a1e57bfc6b020b222a9
```
Wrongly parsing any line even the commented one:
```
>>> search(r'\w+\s+[\*\(]?([^\s\)]+)', result).group(1)
'bytes'
```
Fixed regexp:
```
>>> search(r'^\w+\s+[\*\(]?([^\s\)]+)', result, MULTILINE).group(1)
'Satellite-6.6.0-RHEL-7-20191008.n.0-Satellite-x86_64-dvd1.iso'
```