### PR TITLE
Deploy baseimage with suffix '-base' to use it directly

### DIFF
--- a/automation_tools/baseimage.py
+++ b/automation_tools/baseimage.py
@@ -20,9 +20,9 @@ def detect_imagename(os_url):
     if comp_id.succeeded:
         match_comp = search(r'(\w+)-([\d\.]+)-(?:\w+-)?([\d\.]+)', comp_id)
         image = match_comp.group(1).lower() + match_comp.group(2).replace('.', '') + '-' + \
-            match_comp.group(3)
+            match_comp.group(3) + '-base'
     else:
-        image = 'unknown-{}'.format(str(time.time()).split('.')[0])
+        image = 'unknown-{}-base'.format(str(time.time()).split('.')[0])
 
     print(image)
     return(image)


### PR DESCRIPTION
Let's deploy baseimage with suffix '-base' so that we can use it directly and no other action like symlinking is needed. 
Using symlink as moving target is not a good idea. In future we better change explicitly baseimage name to be more transparent about the change

It brings us these benefits:
- older images (of the same dot release) can still be used
- snapshots (VM instances) based of older images remain viable (yay)