### PR TITLE
Installation of firewalld using foreman-maintain package install.

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -589,7 +589,8 @@ def setup_firewall(definitions=None, flush=True):
             run('iptables --flush')
     else:
         if run('rpm -q firewalld', quiet=True).failed:
-            run('yum install -y firewalld')
+            run('if [ "`yum install -y firewalld 1>&2 2>/dev/null;echo $?`" -ne 0 ]; then'
+                'foreman-maintain packages install -y firewalld ; fi')
         if run('systemctl --no-pager status firewalld', quiet=True).failed:
             run('systemctl enable firewalld')
             run('systemctl start firewalld')


### PR DESCRIPTION
This fix is required for Satellite 6.6 to 6.7 upgrade where the package installation is locked and hence the packages won't be installed pre-upgrade.