### PR TITLE
Fix package_install() failing when run in pre-install time

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -3320,7 +3320,8 @@ def configure_telemetry(http_server=None):
 def package_install(packages, sat_version=None):
     # Fetch the Satellite Version information.
     sat_version = sat_version or os.environ.get('SATELLITE_VERSION')
-    if sat_version is not None and sat_version not in ('6.3', '6.4', '6.5'):
+    if (sat_version not in ('6.3', '6.4', '6.5') and
+       run('which foreman-maintain', warn_only=True).succeeded):
         command = 'foreman-maintain packages install -y {}'.format(packages)
     else:
         command = 'yum -y install {}'.format(packages)


### PR DESCRIPTION
E.g. `setup_firewall` is run before foreman-maintain cmd is present