### PR TITLE
enable remote-execution-cockpit feature

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -54,6 +54,7 @@ from automation_tools import (  # noqa: F401
     setup_python_code_coverage,
     setup_satellite_firewall,
     setup_libvirt_key,
+    setup_local_rex_key,
     setup_proxy,
     setup_ruby_code_coverage,
     setup_rubysys_code_coverage,


### PR DESCRIPTION
this should enable the cockpit webconsole feature in versions 6.7+
and copy the foreman-proxy public rsa key to `/root/.ssh/authorized_keys` to enable REX and cockpit access to the satellite host itself.