### PR TITLE
Avoid firewall reload

### DIFF
--- a/misc/base_image_creation/ks_rhel7_template
+++ b/misc/base_image_creation/ks_rhel7_template
@@ -59,8 +59,8 @@ chmod +x /etc/rc.local
 cat << EOF >> /etc/rc.local
 (
     [ -f /root/setup_configured ] && echo exiting && exit
-    firewall-cmd --add-service mdns --permanent
-    firewall-cmd --reload
+    firewall-cmd --add-service mdns
+    firewall-cmd --runtime-to-permanent
     ntpdate clock.redhat.com
     touch /root/setup_configured
 ) 2>&1 | tee -a /var/log/baseimage-firstboot.log

--- a/misc/base_image_creation/ks_rhel8_template
+++ b/misc/base_image_creation/ks_rhel8_template
@@ -62,8 +62,8 @@ chmod +x /etc/rc.local
 cat << EOF >> /etc/rc.local
 (
     [ -f /root/setup_configured ] && echo exiting && exit
-    firewall-cmd --add-service mdns --permanent
-    firewall-cmd --reload
+    firewall-cmd --add-service mdns
+    firewall-cmd --runtime-to-permanent
     ntpdate clock.redhat.com
     touch /root/setup_configured
 ) 2>&1 | tee -a /var/log/baseimage-firstboot.log


### PR DESCRIPTION
Its better to use 'firewall-cmd --runtime-to-permanent' after configuring the running firewall rather than using reload. Reloading firewall is slower and can beak connections.