### PR TITLE
set UTC time to avoid time jumps

### DIFF
--- a/misc/base_image_creation/ks_rhel7_template
+++ b/misc/base_image_creation/ks_rhel7_template
@@ -15,7 +15,7 @@ network  --bootproto=dhcp --device=eth0 --ipv6=auto --activate
 # Root password
 rootpw --iscrypted ENCRYPT_PASS 
 # System timezone
-timezone America/New_York
+timezone --utc America/New_York
 # System bootloader configuration
 bootloader --location=mbr --boot-drive=vda
 #autopart --type=lvm
@@ -62,7 +62,9 @@ cat << EOF >> /etc/rc.local
     [ -f /root/setup_configured ] && echo exiting && exit
     firewall-cmd --add-service mdns
     firewall-cmd --runtime-to-permanent
+    systemctl stop chronyd
     ntpdate clock.redhat.com
+    systemctl start chronyd
     touch /root/setup_configured
 ) 2>&1 | tee -a /var/log/baseimage-firstboot.log
 EOF

--- a/misc/base_image_creation/ks_rhel8_template
+++ b/misc/base_image_creation/ks_rhel8_template
@@ -14,10 +14,8 @@ lang en_US.UTF-8
 network  --bootproto=dhcp --device=ens3 --ipv6=auto --activate
 # Root password
 rootpw --iscrypted ENCRYPT_PASS 
-# System services
-services --enabled="chronyd"
 # System timezone
-timezone America/New_York
+timezone --utc America/New_York
 # System bootloader configuration
 bootloader --location=mbr --boot-drive=vda
 #autopart --type=lvm
@@ -65,7 +63,9 @@ cat << EOF >> /etc/rc.local
     [ -f /root/setup_configured ] && echo exiting && exit
     firewall-cmd --add-service mdns
     firewall-cmd --runtime-to-permanent
+    systemctl stop chronyd
     ntpdate clock.redhat.com
+    systemctl start chronyd
     touch /root/setup_configured
 ) 2>&1 | tee -a /var/log/baseimage-firstboot.log
 EOF


### PR DESCRIPTION
Chronyd jumps the time in the first few seconds after startup. This can interrupt yum transactions. Setting the time to UTC rather than local can reduce this.