### PR TITLE
Fix SELinux on resolv.conf so chrony can read it

### DIFF
--- a/misc/base_image_creation/ks_rhel7_template
+++ b/misc/base_image_creation/ks_rhel7_template
@@ -44,6 +44,7 @@ qemu-guest-agent
 ssh-keygen -t rsa -N "" -f /root/.ssh/id_dsa
 curl -sS -o /root/.ssh/authorized_keys AUTH_KEYS_URL
 sysctl -w net.ipv6.conf.all.disable_ipv6=1 >> /etc/sysctl.conf
+restorecon /etc/resolv.conf
 sed -Ei 's/^(search.*)/\1\nnameserver NAMESERVER/' /etc/resolv.conf && chattr +i /etc/resolv.conf
 echo 'UseDNS no' >> /etc/ssh/sshd_config
 

--- a/misc/base_image_creation/ks_rhel8_template
+++ b/misc/base_image_creation/ks_rhel8_template
@@ -47,6 +47,7 @@ kexec-tools
 ssh-keygen -t rsa -N "" -f /root/.ssh/id_dsa
 curl -sS -o /root/.ssh/authorized_keys AUTH_KEYS_URL
 sysctl -w net.ipv6.conf.all.disable_ipv6=1 >> /etc/sysctl.conf
+restorecon /etc/resolv.conf
 sed -Ei 's/^(search.*)/\1\nnameserver NAMESERVER/' /etc/resolv.conf && chattr +i /etc/resolv.conf
 echo 'UseDNS no' >> /etc/ssh/sshd_config
 


### PR DESCRIPTION
Hello

incorrect SELinux context was shown in logs when chrony tried to read the resolv.conf file.