### PR TITLE
Workaround: Disable REX cockpit feature for 6.8 presnaps temporarily

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2204,7 +2204,9 @@ def product_install(distribution, certificate_url=None, selinux_mode=None, sat_v
         installer_options.update({'foreman-proxy-plugin-remote-execution-ssh-async-ssh': 'true'})
 
     # enable cockpit feature
-    if (sat_version not in ('6.3', '6.4', '6.5', '6.6')):
+    # if (sat_version not in ('6.3', '6.4', '6.5', '6.6')):
+    # WORKAROUND (no BZ): 6.8 presnaps are failing due to this feature, disable temporarily for 6.8
+    if (sat_version not in ('6.3', '6.4', '6.5', '6.6', '6.8')):
         installer_options.update({'enable-foreman-plugin-remote-execution-cockpit': None})
 
     if os.environ.get('PROXY_INFO'):


### PR DESCRIPTION
This PR unblocks 6.8 presnap automation by disabling REX cockpit  feature for 6.8 as installer is failing due to this.

Though [the fix](https://github.com/theforeman/puppet-foreman/pull/835) is merged it still hasn't made it into a presnap compose
