### PR TITLE
Use API for getting REX ssh pubkey

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1094,7 +1094,7 @@ def setup_local_rex_key():
     """Puts the foreman-proxy public RSA key to authorized_keys of root user
     This allows performing REX jobs (and accessing cockpit console) on the sat host itself
     """
-    run('cat ~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub >> /root/.ssh/authorized_keys')
+    run('wget -nv -O- https://$(hostname):9090/ssh/pubkey >> /root/.ssh/authorized_keys')
 
 
 def vm_create(target_image=None, source_image=None, bridge=None, network=None):

--- a/automation_tools/satellite6/hammer.py
+++ b/automation_tools/satellite6/hammer.py
@@ -374,7 +374,7 @@ def sync_capsule_content(capsule, sync=False):
     for lcenv in lcenvs:
         hammer_capsule_add_lcenv(capsule['id'], lcenv['id'])
     hammer('capsule content synchronize --id {0} {1}'
-           .format(capsule['id']), '' if sync else '--async')
+           .format(capsule['id'], '' if sync else '--async'))
 
 
 def get_product_subscription_id(organization_id, product_name):


### PR DESCRIPTION
...rather than searching for it on the disk

there is issue in presnap 6.8 and getting pubkey using API unblocks automation to finish postinstall tasks