### PR TITLE
Added regex for correct discovery package selection

### DIFF
--- a/automation_tools/utils.py
+++ b/automation_tools/utils.py
@@ -109,7 +109,7 @@ def get_discovery_image():
         url = os.environ.get('BASE_URL') + '/Packages/'
         soup = BeautifulSoup(urlopen(url).read())
         for link in soup.findAll('a'):
-            if 'foreman-discovery-image' in link.string:
+            if re.search(r'foreman-discovery-image-\d+', link.string):
                 discovery_image = link.string
         try:
             run("wget -O /tmp/" + discovery_image + " " + url + discovery_image)


### PR DESCRIPTION
This issue comes in 6.8, where there are multiple numbers of packages with the same prefix(foreman-discovery-image) name, due to that correct foreman-discover-image package selection gets failed.