### PR TITLE
disable async ssh

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -2176,10 +2176,6 @@ def product_install(distribution, certificate_url=None, selinux_mode=None, sat_v
     # enable ostree feature
     installer_options.update({'katello-enable-ostree': 'true'})
 
-    # enable async ssh for rex
-    if version(sat_version) > version(6.6):
-        installer_options.update({'foreman-proxy-plugin-remote-execution-ssh-async-ssh': 'true'})
-
     # enable cockpit feature
     if version(sat_version) > version(6.6):
         installer_options.update({'enable-foreman-plugin-remote-execution-cockpit': None})


### PR DESCRIPTION
As per Dev's comment on BZ, leapp feature (restarting a host via rex) doesn't require async ssh option to be enabled.
This option  was causing remote execution job to show success even when the original job failed at host end.

Refs: PR #821 
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1866689#c7