### PR TITLE
Work around missing centos-release-scl-rh rpm as forklift currently doesn't support RHEL7 with SCL

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -1753,6 +1753,12 @@ def upstream_install(admin_password=None, run_katello_installer=True, **kwargs):
         enable_repos('rhel-*-server-extras-rpms', 'rhel-*-server-optional-rpms')
     # Install required packages for the installation
     run('yum -y install ansible git')
+
+    # Workaround as forklift currently doesn't support RHEL7 with SCL
+    # so we stick to old RHEL + CentOS scl-rh till new way is implemented in forklift
+    run('yum -y install http://yum.theforeman.org/releases/2.2/el7/x86_64/'
+        'centos-release-scl-rh-2-3.el7.centos.noarch.rpm')
+
     run('rm -rf forklift')
     run('git clone -q https://github.com/theforeman/forklift.git')
 


### PR DESCRIPTION
This is workaround to preinstall `centos-release-scl-rh` rpm from Foreman 2.2 as developers dropped the rpm from nightly repo.

This rpm being in nightly repo helped with RHEL + CentOS scl-rh enablement
But this was a hack there should be implemented a proper way in forklift for RHEL + SCL. 

Until implement we go with this workaround.

Fixes:
```
[root@foreman.example.com] out: TASK [foreman_repositories : Install centos-release-scl-rh] ********************
[root@foreman.example.com] out: fatal: [foreman.example.com]: FAILED! => changed=false 
[root@foreman.example.com] out:   msg: No package matching 'centos-release-scl-rh' found available, installed or updated
[root@foreman.example.com] out:   rc: 126
[root@foreman.example.com] out:   results:
[root@foreman.example.com] out:   - No package matching 'centos-release-scl-rh' found available, installed or updated
[root@foreman.example.com] out: 
```