### PR TITLE
Fixes capsule installer and capsule sanity job

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -704,6 +704,7 @@ def setup_capsule_firewall():
             # Subscription Management Services connection to the reverse proxy
             # for the certificate-based API
             8443,
+            5000,
         ),
         'udp': (
             # Queries to the DNS service


### PR DESCRIPTION
capsule installer and capsule sanity job has always been failing. I have investigated failure and noticed that port 5000 was missing in the list.

I referred https://access.redhat.com/documentation/en-us/red_hat_satellite/6.8-beta/html/installing_capsule_server/preparing-environment-for-capsule-installation#capsule-ports-and-firewalls-requirements_capsule for ports required on capsule.

When I ran:

```
# firewall-cmd --add-port="53/udp" --add-port="53/tcp" \ --add-port="67/udp" --add-port="69/udp" \ --add-port="80/tcp" --add-port="443/tcp" \ --add-port="5000/tcp" --add-port="5647/tcp" \ --add-port="8000/tcp" --add-port="8140/tcp" \ --add-port="8443/tcp" --add-port="9090/tcp"

# firewall-cmd --runtime-to-permanent
```
capsule installation completed successfully.