### PR TITLE
Subscribe satellite as the ddns package requires java package

### DIFF
--- a/automation_tools/__init__.py
+++ b/automation_tools/__init__.py
@@ -172,7 +172,7 @@ def setup_ddns(entry_domain, host_ip):
     if ddns_hash is None:
         print('The DDNS_HASH environment variable should be defined')
         sys.exit(1)
-
+    execute(subscribe, host=host_ip)
     ddns_package_url = os.environ.get('DDNS_PACKAGE_URL')
     if ddns_package_url is None:
         print('The DDNS_PACKAGE_URL environment variable should be defined')


### PR DESCRIPTION
There is an update in the ddns package url, which needs the java and causing failure of the job.  see the custom cert job 186 it is fixed with this line of code change. The remaining code needs to be updated in the gitlab repo.     